### PR TITLE
Add search-confidence first slice

### DIFF
--- a/coverage_confidence.py
+++ b/coverage_confidence.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+from math import prod
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class SearchCell:
+    cell_id: str
+    center_lat: float
+    center_lon: float
+    planted_target: bool = False
+
+
+@dataclass(frozen=True)
+class CoveragePass:
+    cell_id: str
+    altitude_m: float
+    recall_estimate: float
+    detected: bool = False
+
+
+def _clamp_probability(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def estimate_cell_confidence(cell: SearchCell, passes: Iterable[CoveragePass]) -> dict[str, object]:
+    matching_passes = [item for item in passes if item.cell_id == cell.cell_id]
+    miss_probability = (
+        prod(1.0 - _clamp_probability(item.recall_estimate) for item in matching_passes)
+        if matching_passes
+        else 1.0
+    )
+    confidence = 1.0 - miss_probability
+    planted_miss = cell.planted_target and not any(item.detected for item in matching_passes)
+    confidence_class = "uncertain" if miss_probability >= 0.50 or planted_miss else "covered"
+    return {
+        "cell_id": cell.cell_id,
+        "center_lat": cell.center_lat,
+        "center_lon": cell.center_lon,
+        "pass_count": len(matching_passes),
+        "miss_probability": round(miss_probability, 12),
+        "confidence": round(confidence, 12),
+        "class": confidence_class,
+        "planted_miss": planted_miss,
+    }
+
+
+def rank_uncertain_cells(
+    cells: Iterable[SearchCell],
+    passes: Iterable[CoveragePass],
+) -> list[dict[str, object]]:
+    pass_list = list(passes)
+    estimates = [estimate_cell_confidence(cell, pass_list) for cell in cells]
+    return sorted(estimates, key=lambda item: float(item["miss_probability"]), reverse=True)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,7 +22,7 @@ This roadmap is bold about direction and conservative about claims. Every new in
 ## Near-term
 
 - Add a detector comparison gate that refuses apples-to-oranges fine-tune claims.
-- Prototype coverage-confidence grid logic with synthetic planted-target validation.
+- Prototype coverage-confidence grid logic with synthetic planted-target mechanics/ranking validation; defer calibrated probability claims until fine-tuned recall inputs and held-out validation exist.
 - Add motion-first candidate tracklets from frame differencing or optical flow.
 - Add a review queue that ranks track-level candidates by uncertainty, motion, and detector evidence.
 - Keep SAR priors minimal at first: last known position, elapsed time, simple movement radius, and optional search-area polygon.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,10 @@
 # Roadmap
 
-This roadmap is intentionally conservative. It identifies future engineering work without implying operational readiness or promising a large feature expansion schedule.
+SAR-INTEL is evolving from a detection-and-map prototype into a search-confidence toolkit:
+
+> What was searched, what was found, what may have been missed, and where should a human review next?
+
+This roadmap is bold about direction and conservative about claims. Every new intelligence feature needs a validation method before it is treated as trustworthy.
 
 ## Completed foundations
 
@@ -12,19 +16,25 @@ This roadmap is intentionally conservative. It identifies future engineering wor
 - Pose-aware flat-ground geotagging
 - Public VisDrone DET validation harness
 - Landing page with GeoJSON demo
+- SHA256-pinned VisDrone validation manifests
+- Fixed-threshold AP / PR-curve reporting for detector comparisons
 
 ## Near-term
 
-- Improve VisDrone validation reporting with threshold sweeps
-- Add annotated frame export for easier visual inspection
-- Add more edge-case tests for pose-aware geotagging and telemetry replay
-- Improve demo/landing-page artifacts as public presentation material
+- Add a detector comparison gate that refuses apples-to-oranges fine-tune claims.
+- Prototype coverage-confidence grid logic with synthetic planted-target validation.
+- Add motion-first candidate tracklets from frame differencing or optical flow.
+- Add a review queue that ranks track-level candidates by uncertainty, motion, and detector evidence.
+- Keep SAR priors minimal at first: last known position, elapsed time, simple movement radius, and optional search-area polygon.
 
 ## Longer-term
 
+- Failure injector for GPS jitter, telemetry dropout, altitude drift, missing frames, corrupted frames, and timestamp gaps
 - Camera calibration workflow
+- Geotag uncertainty ellipses instead of point-only map markers
 - Terrain-aware geotagging experiments
 - Real drone telemetry adapters
 - Video-level tracking validation on public drone datasets
+- Advanced SAR priors only after the core coverage/motion/review loop is tested
 
-The purpose of this roadmap is to show direction and prioritization, not to commit to delivery dates.
+The purpose of this roadmap is to show direction and prioritization, not to commit to delivery dates or operational readiness.

--- a/docs/VISDRONE_VALIDATION.md
+++ b/docs/VISDRONE_VALIDATION.md
@@ -192,6 +192,23 @@ After training, this document should report a before/after comparison:
 
 The goal is to improve aerial-person recall while preserving honest reporting of false positives. A model should count as improved only when recall improves at fixed thresholds without an unacceptable precision collapse, and average precision / PR-curve behavior also improves on the same pinned manifest.
 
+
+## Fine-tune comparison gate
+
+After producing baseline and candidate sweep outputs on the same pinned validation manifest, run the comparison gate:
+
+```bash
+python scripts/compare_visdrone_runs.py \
+  --baseline output/visdrone_det_sweep.json \
+  --candidate output/visdrone_det_finetuned_sweep.json \
+  --recall-delta 0.05 \
+  --min-precision-ratio 0.90 \
+  --ap-delta 0.03 \
+  --output output/visdrone_det_comparison.json
+```
+
+A candidate detector should not be described as improved unless this gate passes on the same validation manifest. The gate requires matching manifest checksums, recall improvement at matching fixed thresholds, no unacceptable precision collapse, and average-precision improvement. This protects the project from accidental split drift and from threshold-shopping that makes recall look better while the detector becomes less useful.
+
 ## How To Improve This Later
 
 - Fine-tune the detector on aerial-person data, including VisDrone-like viewpoints and object scales.

--- a/docs/superpowers/plans/2026-07-01-search-confidence-first-slice.md
+++ b/docs/superpowers/plans/2026-07-01-search-confidence-first-slice.md
@@ -1,0 +1,533 @@
+# Search Confidence First Slice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first executable slice of the SAR-INTEL search-confidence direction: a detector comparison gate and a tested coverage-confidence prototype.
+
+**Architecture:** Keep the detector comparison gate separate from coverage logic. The comparison script validates apples-to-apples VisDrone run outputs; the coverage module consumes already-calibrated recall assumptions and mission-like pass data to produce uncertainty cells. Both pieces are file-based, deterministic, and testable without live drone integration.
+
+**Tech Stack:** Python 3.12, standard library JSON/dataclasses/pathlib/math, pytest, existing VisDrone evaluator JSON outputs.
+
+---
+
+## File Structure
+
+- Create `scripts/compare_visdrone_runs.py`: CLI and pure functions for comparing a baseline evaluator JSON to a candidate evaluator JSON.
+- Create `tests/test_compare_visdrone_runs.py`: TDD coverage for manifest mismatch, fixed-threshold recall improvement, precision-collapse rejection, and AP regression rejection.
+- Create `coverage_confidence.py`: small pure-Python module for search-grid cells, pass evidence, and miss-probability estimates.
+- Create `tests/test_coverage_confidence.py`: synthetic planted-target/coverage behavior tests.
+- Modify `docs/VISDRONE_VALIDATION.md`: document how to run and interpret the comparison gate.
+- Modify `docs/ROADMAP.md`: update after the first slice lands if implementation changes the roadmap wording.
+
+---
+
+### Task 1: Detector Comparison Gate
+
+**Files:**
+- Create: `scripts/compare_visdrone_runs.py`
+- Create: `tests/test_compare_visdrone_runs.py`
+- Modify: `docs/VISDRONE_VALIDATION.md`
+
+- [ ] **Step 1: Write failing tests for comparison behavior**
+
+Create `tests/test_compare_visdrone_runs.py` with:
+
+```python
+import importlib.util
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "compare_visdrone_runs.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("compare_visdrone_runs", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(threshold_rows, checksum="abc123", ap=0.20):
+    return {
+        "mode": "sweep",
+        "average_precision": ap,
+        "validation_manifest": {"checksum": checksum},
+        "results": threshold_rows,
+    }
+
+
+def _row(threshold, precision, recall, f1=0.1):
+    return {
+        "confidence_threshold": threshold,
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "true_positives": 1,
+        "false_positives": 1,
+        "false_negatives": 1,
+    }
+
+
+def test_rejects_manifest_mismatch():
+    module = _load_module()
+    baseline = _run([_row(0.25, precision=0.8, recall=0.10)], checksum="base")
+    candidate = _run([_row(0.25, precision=0.8, recall=0.20)], checksum="candidate")
+
+    result = module.compare_runs(baseline, candidate)
+
+    assert result["passed"] is False
+    assert result["reasons"] == ["validation manifest checksum mismatch"]
+
+
+def test_passes_when_recall_and_ap_improve_without_precision_collapse():
+    module = _load_module()
+    baseline = _run([
+        _row(0.10, precision=0.60, recall=0.20),
+        _row(0.25, precision=0.80, recall=0.10),
+    ], ap=0.30)
+    candidate = _run([
+        _row(0.10, precision=0.58, recall=0.32),
+        _row(0.25, precision=0.78, recall=0.18),
+    ], ap=0.42)
+
+    result = module.compare_runs(
+        baseline,
+        candidate,
+        recall_delta=0.05,
+        min_precision_ratio=0.90,
+        ap_delta=0.03,
+    )
+
+    assert result["passed"] is True
+    assert result["thresholds"]["0.10"]["recall_delta"] == 0.12
+    assert result["thresholds"]["0.25"]["recall_delta"] == 0.08
+
+
+def test_rejects_threshold_shopping_precision_collapse():
+    module = _load_module()
+    baseline = _run([_row(0.25, precision=0.80, recall=0.10)], ap=0.30)
+    candidate = _run([_row(0.25, precision=0.30, recall=0.40)], ap=0.45)
+
+    result = module.compare_runs(
+        baseline,
+        candidate,
+        recall_delta=0.05,
+        min_precision_ratio=0.90,
+        ap_delta=0.03,
+    )
+
+    assert result["passed"] is False
+    assert "precision collapsed at threshold 0.25" in result["reasons"]
+
+
+def test_rejects_average_precision_regression():
+    module = _load_module()
+    baseline = _run([_row(0.25, precision=0.80, recall=0.10)], ap=0.30)
+    candidate = _run([_row(0.25, precision=0.80, recall=0.20)], ap=0.31)
+
+    result = module.compare_runs(
+        baseline,
+        candidate,
+        recall_delta=0.05,
+        min_precision_ratio=0.90,
+        ap_delta=0.03,
+    )
+
+    assert result["passed"] is False
+    assert "average precision did not improve enough" in result["reasons"]
+```
+
+- [ ] **Step 2: Run tests to verify red**
+
+Run:
+
+```bash
+python -m pytest tests/test_compare_visdrone_runs.py -q
+```
+
+Expected: fail because `scripts/compare_visdrone_runs.py` does not exist.
+
+- [ ] **Step 3: Implement comparison script**
+
+Create `scripts/compare_visdrone_runs.py` with pure functions:
+
+```python
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+
+def _threshold_key(value: float) -> str:
+    return f"{float(value):.2f}"
+
+
+def _rows_by_threshold(run: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {_threshold_key(row["confidence_threshold"]): row for row in run.get("results", [])}
+
+
+def _manifest_checksum(run: dict[str, Any]) -> str | None:
+    manifest = run.get("validation_manifest") or {}
+    return manifest.get("checksum")
+
+
+def compare_runs(
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    *,
+    recall_delta: float = 0.05,
+    min_precision_ratio: float = 0.90,
+    ap_delta: float = 0.03,
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    threshold_results: dict[str, dict[str, float]] = {}
+
+    if _manifest_checksum(baseline) != _manifest_checksum(candidate):
+        return {
+            "passed": False,
+            "reasons": ["validation manifest checksum mismatch"],
+            "thresholds": {},
+        }
+
+    baseline_rows = _rows_by_threshold(baseline)
+    candidate_rows = _rows_by_threshold(candidate)
+    common_thresholds = sorted(set(baseline_rows) & set(candidate_rows))
+    if not common_thresholds:
+        reasons.append("no matching fixed thresholds")
+
+    for threshold in common_thresholds:
+        base = baseline_rows[threshold]
+        cand = candidate_rows[threshold]
+        base_precision = float(base["precision"])
+        cand_precision = float(cand["precision"])
+        base_recall = float(base["recall"])
+        cand_recall = float(cand["recall"])
+        precision_ratio = cand_precision / base_precision if base_precision else 0.0
+        current_recall_delta = cand_recall - base_recall
+        threshold_results[threshold] = {
+            "baseline_precision": base_precision,
+            "candidate_precision": cand_precision,
+            "precision_ratio": precision_ratio,
+            "baseline_recall": base_recall,
+            "candidate_recall": cand_recall,
+            "recall_delta": round(current_recall_delta, 12),
+        }
+        if current_recall_delta < recall_delta:
+            reasons.append(f"recall did not improve enough at threshold {threshold}")
+        if precision_ratio < min_precision_ratio:
+            reasons.append(f"precision collapsed at threshold {threshold}")
+
+    baseline_ap = float(baseline.get("average_precision", 0.0))
+    candidate_ap = float(candidate.get("average_precision", 0.0))
+    if candidate_ap - baseline_ap < ap_delta:
+        reasons.append("average precision did not improve enough")
+
+    return {
+        "passed": not reasons,
+        "reasons": reasons,
+        "average_precision": {
+            "baseline": baseline_ap,
+            "candidate": candidate_ap,
+            "delta": round(candidate_ap - baseline_ap, 12),
+        },
+        "thresholds": threshold_results,
+    }
+
+
+def load_json(path: str | Path) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def write_json(data: dict[str, Any], path: str | Path) -> Path:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return output
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compare two VisDrone evaluator sweep outputs.")
+    parser.add_argument("--baseline", required=True)
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--output", default="output/visdrone_det_comparison.json")
+    parser.add_argument("--recall-delta", type=float, default=0.05)
+    parser.add_argument("--min-precision-ratio", type=float, default=0.90)
+    parser.add_argument("--ap-delta", type=float, default=0.03)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    result = compare_runs(
+        load_json(args.baseline),
+        load_json(args.candidate),
+        recall_delta=args.recall_delta,
+        min_precision_ratio=args.min_precision_ratio,
+        ap_delta=args.ap_delta,
+    )
+    output_path = write_json(result, args.output)
+    print(f"Saved VisDrone comparison to {output_path}")
+    if result["passed"]:
+        print("Comparison gate: PASS")
+        return 0
+    print("Comparison gate: FAIL")
+    for reason in result["reasons"]:
+        print(f"- {reason}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run focused tests to green**
+
+Run:
+
+```bash
+python -m pytest tests/test_compare_visdrone_runs.py -q
+```
+
+Expected: `4 passed`.
+
+- [ ] **Step 5: Update validation docs**
+
+Add a section to `docs/VISDRONE_VALIDATION.md` named `## Fine-tune comparison gate` with this command:
+
+```bash
+python scripts/compare_visdrone_runs.py \
+  --baseline output/visdrone_det_sweep.json \
+  --candidate output/visdrone_det_finetuned_sweep.json \
+  --recall-delta 0.05 \
+  --min-precision-ratio 0.90 \
+  --ap-delta 0.03 \
+  --output output/visdrone_det_comparison.json
+```
+
+Explain that a candidate model should not be described as improved unless this gate passes on the same validation manifest.
+
+- [ ] **Step 6: Run full tests and commit**
+
+Run:
+
+```bash
+python -m pytest
+```
+
+Expected: all tests pass.
+
+Commit:
+
+```bash
+git add scripts/compare_visdrone_runs.py tests/test_compare_visdrone_runs.py docs/VISDRONE_VALIDATION.md
+git commit -m "Add VisDrone comparison gate"
+```
+
+---
+
+### Task 2: Coverage Confidence Prototype
+
+**Files:**
+- Create: `coverage_confidence.py`
+- Create: `tests/test_coverage_confidence.py`
+- Modify: `docs/ROADMAP.md` only if the implementation changes terminology.
+
+- [ ] **Step 1: Write failing coverage tests**
+
+Create `tests/test_coverage_confidence.py` with:
+
+```python
+from coverage_confidence import CoveragePass, SearchCell, estimate_cell_confidence, rank_uncertain_cells
+
+
+def test_more_passes_reduce_miss_probability():
+    cell = SearchCell(cell_id="A1", center_lat=43.0, center_lon=-79.0)
+    one_pass = [CoveragePass(cell_id="A1", altitude_m=60.0, recall_estimate=0.30)]
+    three_passes = one_pass * 3
+
+    one = estimate_cell_confidence(cell, one_pass)
+    three = estimate_cell_confidence(cell, three_passes)
+
+    assert one["miss_probability"] == 0.70
+    assert round(three["miss_probability"], 3) == 0.343
+    assert three["confidence"] > one["confidence"]
+
+
+def test_planted_miss_keeps_cell_uncertain():
+    cell = SearchCell(cell_id="B2", center_lat=43.0, center_lon=-79.0, planted_target=True)
+    passes = [CoveragePass(cell_id="B2", altitude_m=80.0, recall_estimate=0.20, detected=False)]
+
+    result = estimate_cell_confidence(cell, passes)
+
+    assert result["class"] == "uncertain"
+    assert result["planted_miss"] is True
+
+
+def test_rank_uncertain_cells_prioritizes_high_miss_probability():
+    cells = [
+        SearchCell(cell_id="A", center_lat=0.0, center_lon=0.0),
+        SearchCell(cell_id="B", center_lat=0.0, center_lon=1.0),
+    ]
+    passes = [
+        CoveragePass(cell_id="A", altitude_m=50.0, recall_estimate=0.80),
+        CoveragePass(cell_id="B", altitude_m=100.0, recall_estimate=0.20),
+    ]
+
+    ranked = rank_uncertain_cells(cells, passes)
+
+    assert [item["cell_id"] for item in ranked] == ["B", "A"]
+```
+
+- [ ] **Step 2: Run tests to verify red**
+
+Run:
+
+```bash
+python -m pytest tests/test_coverage_confidence.py -q
+```
+
+Expected: fail because `coverage_confidence.py` does not exist.
+
+- [ ] **Step 3: Implement minimal coverage module**
+
+Create `coverage_confidence.py` with:
+
+```python
+from dataclasses import dataclass
+from math import prod
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class SearchCell:
+    cell_id: str
+    center_lat: float
+    center_lon: float
+    planted_target: bool = False
+
+
+@dataclass(frozen=True)
+class CoveragePass:
+    cell_id: str
+    altitude_m: float
+    recall_estimate: float
+    detected: bool = False
+
+
+def _clamp_probability(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def estimate_cell_confidence(cell: SearchCell, passes: Iterable[CoveragePass]) -> dict[str, object]:
+    matching_passes = [item for item in passes if item.cell_id == cell.cell_id]
+    miss_probability = prod(
+        1.0 - _clamp_probability(item.recall_estimate) for item in matching_passes
+    ) if matching_passes else 1.0
+    confidence = 1.0 - miss_probability
+    planted_miss = cell.planted_target and not any(item.detected for item in matching_passes)
+    confidence_class = "uncertain" if miss_probability >= 0.50 or planted_miss else "covered"
+    return {
+        "cell_id": cell.cell_id,
+        "center_lat": cell.center_lat,
+        "center_lon": cell.center_lon,
+        "pass_count": len(matching_passes),
+        "miss_probability": round(miss_probability, 12),
+        "confidence": round(confidence, 12),
+        "class": confidence_class,
+        "planted_miss": planted_miss,
+    }
+
+
+def rank_uncertain_cells(cells: Iterable[SearchCell], passes: Iterable[CoveragePass]) -> list[dict[str, object]]:
+    pass_list = list(passes)
+    estimates = [estimate_cell_confidence(cell, pass_list) for cell in cells]
+    return sorted(estimates, key=lambda item: float(item["miss_probability"]), reverse=True)
+```
+
+- [ ] **Step 4: Run focused tests to green**
+
+Run:
+
+```bash
+python -m pytest tests/test_coverage_confidence.py -q
+```
+
+Expected: `3 passed`.
+
+- [ ] **Step 5: Run full tests and commit**
+
+Run:
+
+```bash
+python -m pytest
+```
+
+Expected: all tests pass.
+
+Commit:
+
+```bash
+git add coverage_confidence.py tests/test_coverage_confidence.py docs/ROADMAP.md
+git commit -m "Add coverage confidence prototype"
+```
+
+---
+
+### Task 3: Verification And PR
+
+**Files:**
+- Modify: no source files unless verification reveals a real bug.
+
+- [ ] **Step 1: Run release verification**
+
+Run:
+
+```bash
+python scripts/verify_release.py
+```
+
+Expected: release verification passes. If `sample_data/path.json` is rewritten, restore it with:
+
+```bash
+git restore --source=HEAD -- sample_data/path.json
+```
+
+- [ ] **Step 2: Check final status**
+
+Run:
+
+```bash
+git status -sb
+```
+
+Expected: clean working tree after all commits.
+
+- [ ] **Step 3: Push branch**
+
+Run:
+
+```bash
+git push -u origin codex/search-confidence-roadmap
+```
+
+Expected: branch pushed to GitHub.
+
+- [ ] **Step 4: Open draft PR**
+
+Run:
+
+```bash
+gh pr create --repo Qarait/sar-intel-toolkit --draft --base main --head codex/search-confidence-roadmap --title "Add search-confidence first slice" --body "## Summary
+- Adds a detector comparison gate for same-manifest VisDrone fine-tune claims.
+- Adds the first tested coverage-confidence prototype for miss-probability ranking.
+- Documents the SAR-INTEL search-confidence roadmap and design.
+
+## Validation
+- python -m pytest
+- python scripts\\verify_release.py"
+```
+
+Expected: draft PR URL returned.

--- a/docs/superpowers/specs/2026-07-01-search-confidence-design.md
+++ b/docs/superpowers/specs/2026-07-01-search-confidence-design.md
@@ -1,0 +1,217 @@
+# Search Confidence Design
+
+## Purpose
+
+SAR-INTEL should move beyond "here are detections" and become a search-confidence system:
+
+> What was searched, what was found, what may have been missed, and where should a human review next?
+
+This direction is bold because it treats the current detector weakness as product truth instead of hiding it. A low-recall aerial detector cannot honestly promise complete person finding. It can help measure search coverage, surface uncertain regions, and prioritize human review.
+
+## Product Identity
+
+Primary identity:
+
+> SAR-INTEL turns drone footage into search confidence.
+
+Supporting identity:
+
+> An open, simulation-first SAR triage toolkit that estimates what the drone saw, what it may have missed, and where reviewers should look next.
+
+The project should not compete as the largest aerial detector. It should compete as the most transparent, reviewable, SAR-aware open toolkit for post-flight drone search analysis.
+
+## Build Order
+
+The next phase should be sequenced in this order:
+
+1. Detector calibration and comparison gates.
+2. Coverage-confidence prototype with validation tests.
+3. Motion-first tracklet candidates.
+4. Human review queue ranked by uncertainty, motion, and detector score.
+5. Minimal SAR prior.
+6. Failure injector.
+7. Advanced priors and geotag uncertainty ellipses.
+
+This order keeps the project bold without building a plausible-looking but unvalidated heatmap.
+
+## Module 1: Detector Calibration Gate
+
+Coverage confidence depends on calibrated detector behavior. Before using recall in coverage math, the project needs a repeatable baseline and a fine-tuned comparison path.
+
+Inputs:
+
+- Pinned validation manifest with image/annotation SHA256 hashes.
+- Fixed confidence thresholds, initially `0.10`, `0.25`, and `0.50`.
+- IoU threshold, initially `0.5`.
+- Baseline model output and candidate fine-tuned model output.
+
+Outputs:
+
+- Precision, recall, F1, AP, and PR-curve points.
+- Same-manifest comparison result.
+- Explicit pass/fail gate for whether a model counts as improved.
+
+Improvement should require recall improvement at fixed thresholds without unacceptable precision collapse, plus AP/PR-curve improvement on the same pinned validation manifest.
+
+## Module 2: Coverage Confidence
+
+Coverage confidence is the flagship idea. The output should not be only detected tracks; it should estimate where the search process remains weak.
+
+For each search grid cell, compute:
+
+- Pass count.
+- Approximate camera footprint coverage.
+- Altitude range.
+- Track/detection evidence.
+- Calibrated detector recall estimate for comparable conditions.
+- Miss probability estimate.
+- Confidence class for review and reporting.
+
+Initial version can use simple flat-grid math and coarse altitude bands. It should not require terrain-aware photogrammetry.
+
+Validation must ship with the prototype:
+
+- Synthetic grid with planted targets.
+- Simulated missed detections.
+- Multiple pass-count and altitude scenarios.
+- Assertions that low-coverage and planted-miss cells are classified as uncertain.
+
+The map is not trustworthy merely because it looks good; it is trustworthy only if its uncertainty behavior is tested.
+
+## Module 3: Motion-First Tracklets
+
+Real SAR footage is video, not isolated images. Motion should become a first-class candidate signal.
+
+Pipeline:
+
+```text
+video frames
+  -> frame differencing / optical flow
+  -> small moving candidate blobs
+  -> temporal tracklets
+  -> detector confirmation when available
+  -> reviewer queue
+```
+
+The first version should favor simple, inspectable methods over complex deep models:
+
+- Background differencing between nearby frames.
+- Morphological cleanup.
+- Size and persistence filters.
+- Tracklet scoring by duration, speed stability, and motion contrast.
+
+Motion tracklets should be allowed to surface candidates even when the appearance detector is weak.
+
+## Module 4: Review Queue
+
+The project metric should become:
+
+> true candidates found per reviewer minute
+
+The review queue should rank candidates by:
+
+- Coverage uncertainty.
+- Motion persistence.
+- Detector confidence.
+- Track score.
+- Pass count and altitude.
+
+A reviewer should work at track-level, not frame-level, with fast decisions:
+
+- Confirm.
+- Reject.
+- Uncertain.
+
+The first version can be static or file-based. It does not need accounts, live collaboration, or operational dispatch features.
+
+## Module 5: Minimal SAR Prior
+
+The SAR prior should start deliberately small.
+
+Initial inputs:
+
+- Last known position.
+- Elapsed time.
+- Simple movement radius.
+- Optional search-area polygon.
+
+Deferred inputs:
+
+- Terrain class.
+- Road/trail/water proximity.
+- Lost-person behavior profiles.
+- Formal domain-specific SAR behavior models.
+
+This avoids scope creep while still giving the system a transparent prior that can later fuse with coverage and candidate ranking.
+
+## Module 6: Failure Injector
+
+Because the project is simulation-first, it should deliberately stress itself before anyone trusts it.
+
+Initial perturbations:
+
+- GPS jitter.
+- Telemetry dropout.
+- Altitude drift.
+- Heading drift.
+- Missing frames.
+- Corrupted frames.
+- Timestamp gaps.
+
+Outputs:
+
+- Perturbed mission artifacts.
+- Degradation report.
+- Pass/fail assertions for graceful failure.
+
+This makes operational-envelope honesty visible in the repo, not just written in limitations docs.
+
+## Data Flow
+
+The eventual system is a feedback loop, not a strict waterfall:
+
+```text
+video + telemetry + optional search prior
+  -> detector + motion candidates
+  -> tracklets + map evidence
+  -> coverage confidence
+  -> ranked human review queue
+  -> updated confidence and mission brief
+```
+
+Low-coverage cells can lower the threshold for review candidates. Confirmed or rejected candidates can update later confidence reporting.
+
+## Technical Boundaries
+
+Keep the first implementation small:
+
+- No live drone integration.
+- No operational dispatch workflow.
+- No terrain-aware geotagging requirement.
+- No hidden model claims.
+- No unvalidated confidence maps.
+
+Each intelligence feature needs a matching validation method.
+
+## Testing And Validation
+
+Required validation by module:
+
+- Detector: pinned manifest, fixed thresholds, AP/PR curve.
+- Coverage: planted-target and synthetic-miss calibration tests.
+- Motion: persistence, false-positive, and missed-frame tests.
+- Review queue: deterministic ranking tests and reviewer-workload metrics.
+- Failure injector: perturbation tests and graceful-degradation assertions.
+
+## Success Criteria
+
+This phase succeeds when SAR-INTEL can credibly answer:
+
+- Where did the drone search?
+- How well was each area searched?
+- What did the system find?
+- What might it have missed?
+- What should a human review next?
+- What failed under stress?
+
+The project should feel less like a model demo and more like an honest rescue-intelligence instrument.

--- a/docs/superpowers/specs/2026-07-01-search-confidence-design.md
+++ b/docs/superpowers/specs/2026-07-01-search-confidence-design.md
@@ -51,7 +51,7 @@ Outputs:
 - Same-manifest comparison result.
 - Explicit pass/fail gate for whether a model counts as improved.
 
-Improvement should require recall improvement at fixed thresholds without unacceptable precision collapse, plus AP/PR-curve improvement on the same pinned validation manifest.
+Improvement should require recall improvement at fixed thresholds without unacceptable precision collapse, plus AP/PR-curve improvement on the same pinned validation manifest. Coverage-confidence code must treat recall as an input that can be recalibrated after fine-tuning; it must not bake the current baseline recall into the model as a final truth.
 
 ## Module 2: Coverage Confidence
 
@@ -76,7 +76,9 @@ Validation must ship with the prototype:
 - Multiple pass-count and altitude scenarios.
 - Assertions that low-coverage and planted-miss cells are classified as uncertain.
 
-The map is not trustworthy merely because it looks good; it is trustworthy only if its uncertainty behavior is tested.
+The first prototype validates mechanics and ranking behavior on synthetic inputs: weaker coverage produces higher miss probability, planted targets without detections remain uncertain, and uncertain cells can be prioritized for review. It does not yet prove calibrated real-world probabilities. A cell with `0.70` miss probability should not be described as a real-world 70% miss rate until the detector has been calibrated against appropriate aerial/SAR data and the coverage model has been validated against held-out planted-target or field-like footage.
+
+The map is not trustworthy merely because it looks good; it is trustworthy only if its uncertainty behavior is tested and its recall inputs are recalibrated when better detector metrics become available.
 
 ## Module 3: Motion-First Tracklets
 
@@ -198,7 +200,7 @@ Each intelligence feature needs a matching validation method.
 Required validation by module:
 
 - Detector: pinned manifest, fixed thresholds, AP/PR curve.
-- Coverage: planted-target and synthetic-miss calibration tests.
+- Coverage: planted-target and synthetic-miss mechanics/ranking tests first; calibrated probability tests only after calibrated detector recall inputs exist.
 - Motion: persistence, false-positive, and missed-frame tests.
 - Review queue: deterministic ranking tests and reviewer-workload metrics.
 - Failure injector: perturbation tests and graceful-degradation assertions.

--- a/scripts/compare_visdrone_runs.py
+++ b/scripts/compare_visdrone_runs.py
@@ -1,0 +1,126 @@
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+
+def _threshold_key(value: float) -> str:
+    return f"{float(value):.2f}"
+
+
+def _rows_by_threshold(run: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {_threshold_key(row["confidence_threshold"]): row for row in run.get("results", [])}
+
+
+def _manifest_checksum(run: dict[str, Any]) -> str | None:
+    manifest = run.get("validation_manifest") or {}
+    return manifest.get("checksum")
+
+
+def compare_runs(
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    *,
+    recall_delta: float = 0.05,
+    min_precision_ratio: float = 0.90,
+    ap_delta: float = 0.03,
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    threshold_results: dict[str, dict[str, float]] = {}
+
+    if _manifest_checksum(baseline) != _manifest_checksum(candidate):
+        return {
+            "passed": False,
+            "reasons": ["validation manifest checksum mismatch"],
+            "thresholds": {},
+        }
+
+    baseline_rows = _rows_by_threshold(baseline)
+    candidate_rows = _rows_by_threshold(candidate)
+    common_thresholds = sorted(set(baseline_rows) & set(candidate_rows))
+    if not common_thresholds:
+        reasons.append("no matching fixed thresholds")
+
+    for threshold in common_thresholds:
+        base = baseline_rows[threshold]
+        cand = candidate_rows[threshold]
+        base_precision = float(base["precision"])
+        cand_precision = float(cand["precision"])
+        base_recall = float(base["recall"])
+        cand_recall = float(cand["recall"])
+        precision_ratio = cand_precision / base_precision if base_precision else 0.0
+        current_recall_delta = cand_recall - base_recall
+        threshold_results[threshold] = {
+            "baseline_precision": base_precision,
+            "candidate_precision": cand_precision,
+            "precision_ratio": precision_ratio,
+            "baseline_recall": base_recall,
+            "candidate_recall": cand_recall,
+            "recall_delta": round(current_recall_delta, 12),
+        }
+        if current_recall_delta < recall_delta:
+            reasons.append(f"recall did not improve enough at threshold {threshold}")
+        if precision_ratio < min_precision_ratio:
+            reasons.append(f"precision collapsed at threshold {threshold}")
+
+    baseline_ap = float(baseline.get("average_precision", 0.0))
+    candidate_ap = float(candidate.get("average_precision", 0.0))
+    if candidate_ap - baseline_ap < ap_delta:
+        reasons.append("average precision did not improve enough")
+
+    return {
+        "passed": not reasons,
+        "reasons": reasons,
+        "average_precision": {
+            "baseline": baseline_ap,
+            "candidate": candidate_ap,
+            "delta": round(candidate_ap - baseline_ap, 12),
+        },
+        "thresholds": threshold_results,
+    }
+
+
+def load_json(path: str | Path) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def write_json(data: dict[str, Any], path: str | Path) -> Path:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return output
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compare two VisDrone evaluator sweep outputs.")
+    parser.add_argument("--baseline", required=True)
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--output", default="output/visdrone_det_comparison.json")
+    parser.add_argument("--recall-delta", type=float, default=0.05)
+    parser.add_argument("--min-precision-ratio", type=float, default=0.90)
+    parser.add_argument("--ap-delta", type=float, default=0.03)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    result = compare_runs(
+        load_json(args.baseline),
+        load_json(args.candidate),
+        recall_delta=args.recall_delta,
+        min_precision_ratio=args.min_precision_ratio,
+        ap_delta=args.ap_delta,
+    )
+    output_path = write_json(result, args.output)
+    print(f"Saved VisDrone comparison to {output_path}")
+    if result["passed"]:
+        print("Comparison gate: PASS")
+        return 0
+    print("Comparison gate: FAIL")
+    for reason in result["reasons"]:
+        print(f"- {reason}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_compare_visdrone_runs.py
+++ b/tests/test_compare_visdrone_runs.py
@@ -1,0 +1,104 @@
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "compare_visdrone_runs.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("compare_visdrone_runs", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(threshold_rows, checksum="abc123", ap=0.20):
+    return {
+        "mode": "sweep",
+        "average_precision": ap,
+        "validation_manifest": {"checksum": checksum},
+        "results": threshold_rows,
+    }
+
+
+def _row(threshold, precision, recall, f1=0.1):
+    return {
+        "confidence_threshold": threshold,
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "true_positives": 1,
+        "false_positives": 1,
+        "false_negatives": 1,
+    }
+
+
+def test_rejects_manifest_mismatch():
+    module = _load_module()
+    baseline = _run([_row(0.25, precision=0.8, recall=0.10)], checksum="base")
+    candidate = _run([_row(0.25, precision=0.8, recall=0.20)], checksum="candidate")
+
+    result = module.compare_runs(baseline, candidate)
+
+    assert result["passed"] is False
+    assert result["reasons"] == ["validation manifest checksum mismatch"]
+
+
+def test_passes_when_recall_and_ap_improve_without_precision_collapse():
+    module = _load_module()
+    baseline = _run([
+        _row(0.10, precision=0.60, recall=0.20),
+        _row(0.25, precision=0.80, recall=0.10),
+    ], ap=0.30)
+    candidate = _run([
+        _row(0.10, precision=0.58, recall=0.32),
+        _row(0.25, precision=0.78, recall=0.18),
+    ], ap=0.42)
+
+    result = module.compare_runs(
+        baseline,
+        candidate,
+        recall_delta=0.05,
+        min_precision_ratio=0.90,
+        ap_delta=0.03,
+    )
+
+    assert result["passed"] is True
+    assert result["thresholds"]["0.10"]["recall_delta"] == 0.12
+    assert result["thresholds"]["0.25"]["recall_delta"] == 0.08
+
+
+def test_rejects_threshold_shopping_precision_collapse():
+    module = _load_module()
+    baseline = _run([_row(0.25, precision=0.80, recall=0.10)], ap=0.30)
+    candidate = _run([_row(0.25, precision=0.30, recall=0.40)], ap=0.45)
+
+    result = module.compare_runs(
+        baseline,
+        candidate,
+        recall_delta=0.05,
+        min_precision_ratio=0.90,
+        ap_delta=0.03,
+    )
+
+    assert result["passed"] is False
+    assert "precision collapsed at threshold 0.25" in result["reasons"]
+
+
+def test_rejects_average_precision_regression():
+    module = _load_module()
+    baseline = _run([_row(0.25, precision=0.80, recall=0.10)], ap=0.30)
+    candidate = _run([_row(0.25, precision=0.80, recall=0.20)], ap=0.31)
+
+    result = module.compare_runs(
+        baseline,
+        candidate,
+        recall_delta=0.05,
+        min_precision_ratio=0.90,
+        ap_delta=0.03,
+    )
+
+    assert result["passed"] is False
+    assert "average precision did not improve enough" in result["reasons"]

--- a/tests/test_coverage_confidence.py
+++ b/tests/test_coverage_confidence.py
@@ -1,0 +1,39 @@
+from coverage_confidence import CoveragePass, SearchCell, estimate_cell_confidence, rank_uncertain_cells
+
+
+def test_more_passes_reduce_miss_probability():
+    cell = SearchCell(cell_id="A1", center_lat=43.0, center_lon=-79.0)
+    one_pass = [CoveragePass(cell_id="A1", altitude_m=60.0, recall_estimate=0.30)]
+    three_passes = one_pass * 3
+
+    one = estimate_cell_confidence(cell, one_pass)
+    three = estimate_cell_confidence(cell, three_passes)
+
+    assert one["miss_probability"] == 0.70
+    assert round(three["miss_probability"], 3) == 0.343
+    assert three["confidence"] > one["confidence"]
+
+
+def test_planted_miss_keeps_cell_uncertain():
+    cell = SearchCell(cell_id="B2", center_lat=43.0, center_lon=-79.0, planted_target=True)
+    passes = [CoveragePass(cell_id="B2", altitude_m=80.0, recall_estimate=0.20, detected=False)]
+
+    result = estimate_cell_confidence(cell, passes)
+
+    assert result["class"] == "uncertain"
+    assert result["planted_miss"] is True
+
+
+def test_rank_uncertain_cells_prioritizes_high_miss_probability():
+    cells = [
+        SearchCell(cell_id="A", center_lat=0.0, center_lon=0.0),
+        SearchCell(cell_id="B", center_lat=0.0, center_lon=1.0),
+    ]
+    passes = [
+        CoveragePass(cell_id="A", altitude_m=50.0, recall_estimate=0.80),
+        CoveragePass(cell_id="B", altitude_m=100.0, recall_estimate=0.20),
+    ]
+
+    ranked = rank_uncertain_cells(cells, passes)
+
+    assert [item["cell_id"] for item in ranked] == ["B", "A"]


### PR DESCRIPTION
## Summary
- Defines the SAR-INTEL search-confidence direction in a design spec and roadmap update.
- Adds a VisDrone comparison gate for same-manifest fine-tune claims using fixed thresholds, precision-collapse checks, and AP improvement.
- Adds the first tested coverage-confidence prototype for miss-probability ranking over search cells.
- Clarifies that planted-target tests currently validate mechanics/ranking behavior, not real-world calibrated probability, and that recall inputs must be recalibrated after fine-tuning.

## Validation
- `python -m pytest` - 58 passed.
- `python scripts\verify_release.py` - compile ok, unit tests ok, offline config ok, replay config ok, acceptance pipeline ok.

## Notes
- This is intentionally draft: it establishes the next-phase spine without claiming operational SAR readiness.
- Coverage confidence is the bold direction, but calibrated probability claims remain gated on fine-tuned detector metrics and held-out planted-target or field-like validation.