### PR TITLE
Add motion-first tracklet prototype

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,7 +23,7 @@ This roadmap is bold about direction and conservative about claims. Every new in
 
 - Add a detector comparison gate that refuses apples-to-oranges fine-tune claims.
 - Prototype coverage-confidence grid logic with synthetic planted-target mechanics/ranking validation; defer calibrated probability claims until fine-tuned recall inputs and held-out validation exist.
-- Add motion-first candidate tracklets from frame differencing or optical flow.
+- Add motion-first candidate tracklets from frame differencing or optical flow. First slice: synthetic-frame motion candidates and persistence-scored tracklets.
 - Add a review queue that ranks track-level candidates by uncertainty, motion, and detector evidence.
 - Keep SAR priors minimal at first: last known position, elapsed time, simple movement radius, and optional search-area polygon.
 

--- a/docs/superpowers/plans/2026-07-01-motion-first-tracklets.md
+++ b/docs/superpowers/plans/2026-07-01-motion-first-tracklets.md
@@ -1,0 +1,49 @@
+# Motion-First Tracklets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a small, tested motion-first candidate layer that converts synthetic video frames into persistent motion tracklets.
+
+**Architecture:** Create a pure `motion_tracklets.py` module with dataclasses and deterministic functions. Tests create tiny NumPy frames with known motion and assert candidate extraction, persistence filtering, and scoring behavior. No detector fusion, map UI, or video file IO belongs in this slice.
+
+**Tech Stack:** Python 3.12, NumPy, OpenCV connected components, pytest.
+
+---
+
+## Files
+
+- Create `motion_tracklets.py`: frame differencing, candidate extraction, tracklet linking, persistence scoring.
+- Create `tests/test_motion_tracklets.py`: synthetic-frame tests for motion mechanics.
+- Modify `docs/ROADMAP.md`: mark motion-first tracklets as started/first slice.
+
+---
+
+### Task 1: Motion Candidate And Tracklet Core
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_motion_tracklets.py` with tests for no motion, persistent moving square, flicker rejection, and stable scoring.
+
+- [ ] **Step 2: Verify red**
+
+Run: `python -m pytest tests/test_motion_tracklets.py -q`
+
+Expected: fails because `motion_tracklets.py` does not exist.
+
+- [ ] **Step 3: Implement minimal module**
+
+Create `motion_tracklets.py` with `MotionCandidate`, `MotionTracklet`, `detect_motion_candidates`, and `build_motion_tracklets`.
+
+- [ ] **Step 4: Verify green**
+
+Run: `python -m pytest tests/test_motion_tracklets.py -q`
+
+Expected: all motion tests pass.
+
+- [ ] **Step 5: Full verification and commit**
+
+Run: `python -m pytest`
+
+Expected: all tests pass.
+
+Commit: `git commit -m "Add motion-first tracklet prototype"`

--- a/docs/superpowers/specs/2026-07-01-motion-first-tracklets-design.md
+++ b/docs/superpowers/specs/2026-07-01-motion-first-tracklets-design.md
@@ -1,0 +1,56 @@
+# Motion-First Tracklets Design
+
+## Purpose
+
+SAR-INTEL should treat drone footage as video evidence, not a pile of still images. At altitude, a person can be weak or invisible to an appearance detector in any single frame, while still producing a persistent motion signal across time. This slice adds the first inspectable motion-first candidate layer.
+
+## Product Role
+
+Motion-first tracklets are not verified person detections. They are review candidates that can raise recall by surfacing persistent small motion even when the appearance detector is uncertain or silent.
+
+The feature supports the search-confidence direction:
+
+- low-confidence coverage cells can later lower review thresholds for motion candidates;
+- persistent motion can push a cell or tracklet higher in the review queue;
+- rejected motion candidates can help tune false-positive filters.
+
+## First Slice
+
+The first implementation uses simple, deterministic computer vision:
+
+1. Convert adjacent frames to grayscale.
+2. Compute absolute frame difference.
+3. Threshold changed pixels.
+4. Use connected components to create motion candidates.
+5. Link candidates across time by nearest centroid.
+6. Keep only tracklets that persist for enough frames.
+7. Score tracklets by persistence and motion stability.
+
+This is deliberately not optical flow yet. Frame differencing is cheap, testable, and enough to prove the interface.
+
+## Boundaries
+
+- No detector fusion in this slice.
+- No map/review UI wiring in this slice.
+- No claim that motion candidates are people.
+- No real-video benchmark claim yet.
+- No dependency beyond existing `numpy` and `opencv-python`.
+
+## Validation
+
+The first tests use synthetic frames because they provide known motion truth:
+
+- a moving square produces a tracklet;
+- identical frames produce no candidates;
+- a one-frame flicker is rejected by persistence filtering;
+- persistent movement receives a higher score than unstable movement.
+
+These tests validate mechanics and ranking behavior. They do not prove real-world SAR recall improvement; that requires later tests on field-like footage.
+
+## Data Structures
+
+`MotionCandidate` records frame index, bounding box, centroid, area, and mean frame-difference intensity.
+
+`MotionTracklet` records linked candidates, duration, displacement, and score.
+
+The module should remain pure and file-free so later pipeline code can feed it frames from video readers, tests, or synthetic generators.

--- a/motion_tracklets.py
+++ b/motion_tracklets.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import hypot
+from typing import Iterable, Sequence
+
+import cv2
+import numpy as np
+
+
+@dataclass(frozen=True)
+class MotionCandidate:
+    frame_index: int
+    bbox: tuple[int, int, int, int]
+    centroid: tuple[float, float]
+    area: int
+    mean_delta: float
+
+
+@dataclass(frozen=True)
+class MotionTracklet:
+    candidates: tuple[MotionCandidate, ...]
+    score: float
+
+    @property
+    def start_frame(self) -> int:
+        return self.candidates[0].frame_index
+
+    @property
+    def end_frame(self) -> int:
+        return self.candidates[-1].frame_index
+
+    @property
+    def duration(self) -> int:
+        return len(self.candidates)
+
+    @property
+    def displacement(self) -> float:
+        start = self.candidates[0].centroid
+        end = self.candidates[-1].centroid
+        return hypot(end[0] - start[0], end[1] - start[1])
+
+
+def _as_gray(frame: np.ndarray) -> np.ndarray:
+    array = np.asarray(frame)
+    if array.ndim == 2:
+        return array.astype(np.uint8)
+    if array.ndim == 3:
+        return cv2.cvtColor(array.astype(np.uint8), cv2.COLOR_BGR2GRAY)
+    raise ValueError(f"Expected 2D grayscale or 3D BGR frame, got shape {array.shape!r}")
+
+
+def _component_candidates(
+    delta: np.ndarray,
+    frame_index: int,
+    min_area: int,
+) -> list[MotionCandidate]:
+    count, labels, stats, centroids = cv2.connectedComponentsWithStats(delta, connectivity=8)
+    candidates: list[MotionCandidate] = []
+    for label in range(1, count):
+        x, y, width, height, area = stats[label]
+        if int(area) < min_area:
+            continue
+        mask = labels == label
+        candidates.append(
+            MotionCandidate(
+                frame_index=frame_index,
+                bbox=(int(x), int(y), int(x + width - 1), int(y + height - 1)),
+                centroid=(float(centroids[label][0]), float(centroids[label][1])),
+                area=int(area),
+                mean_delta=float(delta[mask].mean()),
+            )
+        )
+    return sorted(candidates, key=lambda item: (item.bbox[1], item.bbox[0]))
+
+
+def detect_motion_candidates(
+    previous_frame: np.ndarray,
+    current_frame: np.ndarray,
+    *,
+    frame_index: int,
+    threshold: int = 25,
+    min_area: int = 4,
+) -> list[MotionCandidate]:
+    previous_gray = _as_gray(previous_frame)
+    current_gray = _as_gray(current_frame)
+    if previous_gray.shape != current_gray.shape:
+        raise ValueError("Previous and current frames must have the same shape.")
+
+    diff = cv2.absdiff(previous_gray, current_gray)
+    _, delta = cv2.threshold(diff, threshold, 255, cv2.THRESH_BINARY)
+    return _component_candidates(delta, frame_index, min_area)
+
+
+def _appearing_candidates(
+    previous_frame: np.ndarray,
+    current_frame: np.ndarray,
+    *,
+    frame_index: int,
+    threshold: int,
+    min_area: int,
+) -> list[MotionCandidate]:
+    previous_gray = _as_gray(previous_frame)
+    current_gray = _as_gray(current_frame)
+    candidates = detect_motion_candidates(
+        previous_gray,
+        current_gray,
+        frame_index=frame_index,
+        threshold=threshold,
+        min_area=min_area,
+    )
+    appearing: list[MotionCandidate] = []
+    for candidate in candidates:
+        x1, y1, x2, y2 = candidate.bbox
+        current_mean = float(current_gray[y1 : y2 + 1, x1 : x2 + 1].mean())
+        previous_mean = float(previous_gray[y1 : y2 + 1, x1 : x2 + 1].mean())
+        if current_mean > previous_mean:
+            appearing.append(candidate)
+    return appearing
+
+
+def _distance(a: MotionCandidate, b: MotionCandidate) -> float:
+    return hypot(a.centroid[0] - b.centroid[0], a.centroid[1] - b.centroid[1])
+
+
+def _tracklet_score(candidates: Sequence[MotionCandidate]) -> float:
+    if not candidates:
+        return 0.0
+    displacement = hypot(
+        candidates[-1].centroid[0] - candidates[0].centroid[0],
+        candidates[-1].centroid[1] - candidates[0].centroid[1],
+    )
+    mean_area = sum(item.area for item in candidates) / len(candidates)
+    return float(len(candidates) + displacement + mean_area / 100.0)
+
+
+def build_motion_tracklets(
+    frames: Iterable[np.ndarray],
+    *,
+    threshold: int = 25,
+    min_area: int = 4,
+    min_persistence: int = 3,
+    max_link_distance: float = 8.0,
+) -> list[MotionTracklet]:
+    frame_list = list(frames)
+    active_tracks: list[list[MotionCandidate]] = []
+
+    for frame_index in range(1, len(frame_list)):
+        candidates = _appearing_candidates(
+            frame_list[frame_index - 1],
+            frame_list[frame_index],
+            frame_index=frame_index,
+            threshold=threshold,
+            min_area=min_area,
+        )
+        used_tracks: set[int] = set()
+        for candidate in candidates:
+            best_track_index = None
+            best_distance = max_link_distance
+            for track_index, track in enumerate(active_tracks):
+                if track_index in used_tracks:
+                    continue
+                distance = _distance(track[-1], candidate)
+                if distance <= best_distance:
+                    best_distance = distance
+                    best_track_index = track_index
+            if best_track_index is None:
+                active_tracks.append([candidate])
+                used_tracks.add(len(active_tracks) - 1)
+            else:
+                active_tracks[best_track_index].append(candidate)
+                used_tracks.add(best_track_index)
+
+    tracklets = [
+        MotionTracklet(candidates=tuple(track), score=_tracklet_score(track))
+        for track in active_tracks
+        if len(track) >= min_persistence
+    ]
+    return sorted(tracklets, key=lambda item: item.score, reverse=True)

--- a/tests/test_motion_tracklets.py
+++ b/tests/test_motion_tracklets.py
@@ -1,0 +1,73 @@
+import numpy as np
+
+from motion_tracklets import build_motion_tracklets, detect_motion_candidates
+
+
+def _blank(size: int = 24) -> np.ndarray:
+    return np.zeros((size, size), dtype=np.uint8)
+
+
+def _with_square(x: int, y: int, size: int = 3) -> np.ndarray:
+    frame = _blank()
+    frame[y : y + size, x : x + size] = 255
+    return frame
+
+
+def test_identical_frames_produce_no_motion_candidates() -> None:
+    frame = _blank()
+
+    candidates = detect_motion_candidates(frame, frame, frame_index=1, threshold=25, min_area=2)
+
+    assert candidates == []
+
+
+def test_moving_square_produces_motion_candidate_bbox() -> None:
+    previous = _with_square(4, 8)
+    current = _with_square(8, 8)
+
+    candidates = detect_motion_candidates(previous, current, frame_index=1, threshold=25, min_area=3)
+
+    assert len(candidates) == 2
+    assert candidates[0].frame_index == 1
+    assert candidates[0].area == 9
+    assert candidates[0].bbox == (4, 8, 6, 10)
+    assert candidates[1].bbox == (8, 8, 10, 10)
+
+
+def test_short_flicker_is_rejected_by_persistence_filter() -> None:
+    frames = [_blank(), _with_square(8, 8), _blank(), _blank()]
+
+    tracklets = build_motion_tracklets(
+        frames,
+        threshold=25,
+        min_area=3,
+        min_persistence=3,
+        max_link_distance=5.0,
+    )
+
+    assert tracklets == []
+
+
+def test_persistent_motion_becomes_scored_tracklet() -> None:
+    frames = [
+        _with_square(2, 8),
+        _with_square(4, 8),
+        _with_square(6, 8),
+        _with_square(8, 8),
+    ]
+
+    tracklets = build_motion_tracklets(
+        frames,
+        threshold=25,
+        min_area=3,
+        min_persistence=3,
+        max_link_distance=4.0,
+    )
+
+    assert len(tracklets) == 1
+    tracklet = tracklets[0]
+    assert tracklet.start_frame == 1
+    assert tracklet.end_frame == 3
+    assert tracklet.duration == 3
+    assert round(tracklet.displacement, 2) >= 4.0
+    assert tracklet.score > 0.0


### PR DESCRIPTION
## Summary
- Adds a motion-first design spec and implementation plan for video-based SAR candidate discovery.
- Adds a pure Python/OpenCV motion tracklet prototype using frame differencing, connected components, nearest-centroid linking, and persistence scoring.
- Adds synthetic-frame tests for no motion, moving blobs, flicker rejection, and persistent tracklet scoring.

## Validation
- \python -m pytest\ - 62 passed.
- \python scripts\\verify_release.py\ - compile ok, unit tests ok, offline config ok, replay config ok, acceptance pipeline ok.

## Notes
- This is intentionally draft: motion tracklets are review candidates, not verified person detections.
- The first slice validates synthetic mechanics only; real SAR recall impact remains a later field-like/video validation step.