### PR TITLE
Add tracklet review export

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,7 +24,7 @@ This roadmap is bold about direction and conservative about claims. Every new in
 - Add a detector comparison gate that refuses apples-to-oranges fine-tune claims.
 - Prototype coverage-confidence grid logic with synthetic planted-target mechanics/ranking validation; defer calibrated probability claims until fine-tuned recall inputs and held-out validation exist.
 - Add motion-first candidate tracklets from frame differencing or optical flow. First slice: synthetic-frame motion candidates and persistence-scored tracklets.
-- Add a review queue that ranks track-level candidates by uncertainty, motion, and detector evidence.
+- Add a review queue that ranks track-level candidates by uncertainty, motion, and detector evidence. First slice: JSON-ready motion records and uncertainty-weighted review ranking.
 - Keep SAR priors minimal at first: last known position, elapsed time, simple movement radius, and optional search-area polygon.
 
 ## Longer-term

--- a/docs/superpowers/specs/2026-07-01-tracklet-review-export-design.md
+++ b/docs/superpowers/specs/2026-07-01-tracklet-review-export-design.md
@@ -1,0 +1,19 @@
+# Tracklet Review Export Design
+
+## Purpose
+
+Motion tracklets need to leave the algorithm layer as reviewable artifacts. This slice creates a small JSON-ready representation and a deterministic review queue so later UI and coverage-map work can consume motion candidates without re-running video analysis.
+
+## Scope
+
+The slice exports motion tracklets with frame range, duration, score, displacement, and per-frame candidate geometry. It also ranks review items by motion score plus coverage miss probability.
+
+## Boundaries
+
+- Tracklet records are review candidates, not confirmed people.
+- Queue status starts as `unreviewed`; confirm/reject/uncertain persistence is a later slice.
+- Coverage uncertainty is consumed as an input keyed by tracklet ID; this slice does not compute map cells.
+
+## Validation
+
+Synthetic tests assert JSON-ready serialization, uncertainty-first ranking, and safe defaults when coverage evidence is missing.

--- a/review_queue.py
+++ b/review_queue.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+from motion_tracklets import MotionTracklet
+
+
+def _tracklet_id(tracklet: MotionTracklet, index: int | None = None) -> str:
+    existing = getattr(tracklet, "tracklet_id", None)
+    if existing is not None:
+        return str(existing)
+    if index is None:
+        return f"motion-{tracklet.start_frame}-{tracklet.end_frame}"
+    return f"motion-{index:04d}"
+
+
+def motion_tracklet_to_record(tracklet: MotionTracklet, *, tracklet_id: str | None = None) -> dict[str, Any]:
+    record_id = tracklet_id or _tracklet_id(tracklet)
+    return {
+        "tracklet_id": record_id,
+        "start_frame": tracklet.start_frame,
+        "end_frame": tracklet.end_frame,
+        "duration": tracklet.duration,
+        "score": tracklet.score,
+        "displacement": round(tracklet.displacement, 12),
+        "candidates": [
+            {
+                "frame_index": candidate.frame_index,
+                "bbox": list(candidate.bbox),
+                "centroid": [candidate.centroid[0], candidate.centroid[1]],
+                "area": candidate.area,
+                "mean_delta": candidate.mean_delta,
+            }
+            for candidate in tracklet.candidates
+        ],
+    }
+
+
+def build_review_queue(
+    tracklets: Iterable[MotionTracklet],
+    *,
+    coverage_by_tracklet: Mapping[str, Mapping[str, float]],
+    uncertainty_weight: float = 10.0,
+) -> list[dict[str, Any]]:
+    queue: list[dict[str, Any]] = []
+    for index, tracklet in enumerate(tracklets, start=1):
+        tracklet_id = _tracklet_id(tracklet, index)
+        record = motion_tracklet_to_record(tracklet, tracklet_id=tracklet_id)
+        miss_probability = float(coverage_by_tracklet.get(tracklet_id, {}).get("miss_probability", 0.0))
+        priority = float(tracklet.score) + miss_probability * uncertainty_weight
+        record.update(
+            {
+                "coverage_miss_probability": miss_probability,
+                "review_priority": round(priority, 12),
+                "status": "unreviewed",
+            }
+        )
+        queue.append(record)
+    return sorted(queue, key=lambda item: float(item["review_priority"]), reverse=True)

--- a/tests/test_review_queue.py
+++ b/tests/test_review_queue.py
@@ -1,0 +1,69 @@
+from motion_tracklets import MotionCandidate, MotionTracklet
+from review_queue import build_review_queue, motion_tracklet_to_record
+
+
+def _candidate(frame_index: int, x: int, y: int) -> MotionCandidate:
+    return MotionCandidate(
+        frame_index=frame_index,
+        bbox=(x, y, x + 2, y + 2),
+        centroid=(float(x + 1), float(y + 1)),
+        area=9,
+        mean_delta=255.0,
+    )
+
+
+def _tracklet(tracklet_id: str, score: float, start_x: int = 2) -> MotionTracklet:
+    base = MotionTracklet(
+        candidates=(
+            _candidate(1, start_x, 8),
+            _candidate(2, start_x + 2, 8),
+            _candidate(3, start_x + 4, 8),
+        ),
+        score=score,
+    )
+    object.__setattr__(base, "tracklet_id", tracklet_id)
+    return base
+
+
+def test_motion_tracklet_serializes_to_json_ready_record() -> None:
+    record = motion_tracklet_to_record(_tracklet("m-1", score=7.5))
+
+    assert record == {
+        "tracklet_id": "m-1",
+        "start_frame": 1,
+        "end_frame": 3,
+        "duration": 3,
+        "score": 7.5,
+        "displacement": 4.0,
+        "candidates": [
+            {"frame_index": 1, "bbox": [2, 8, 4, 10], "centroid": [3.0, 9.0], "area": 9, "mean_delta": 255.0},
+            {"frame_index": 2, "bbox": [4, 8, 6, 10], "centroid": [5.0, 9.0], "area": 9, "mean_delta": 255.0},
+            {"frame_index": 3, "bbox": [6, 8, 8, 10], "centroid": [7.0, 9.0], "area": 9, "mean_delta": 255.0},
+        ],
+    }
+
+
+def test_review_queue_ranks_uncertainty_before_raw_motion_score() -> None:
+    high_motion_low_uncertainty = _tracklet("fast-covered", score=10.0, start_x=2)
+    lower_motion_high_uncertainty = _tracklet("slow-uncertain", score=6.0, start_x=10)
+    coverage = {
+        "fast-covered": {"miss_probability": 0.20},
+        "slow-uncertain": {"miss_probability": 0.85},
+    }
+
+    queue = build_review_queue(
+        [high_motion_low_uncertainty, lower_motion_high_uncertainty],
+        coverage_by_tracklet=coverage,
+    )
+
+    assert [item["tracklet_id"] for item in queue] == ["slow-uncertain", "fast-covered"]
+    assert queue[0]["review_priority"] > queue[1]["review_priority"]
+    assert queue[0]["status"] == "unreviewed"
+
+
+def test_review_queue_defaults_missing_coverage_to_zero_uncertainty() -> None:
+    queue = build_review_queue([_tracklet("motion-only", score=4.0)], coverage_by_tracklet={})
+
+    assert queue[0]["tracklet_id"] == "motion-only"
+    assert queue[0]["coverage_miss_probability"] == 0.0
+    assert queue[0]["review_priority"] == 4.0


### PR DESCRIPTION
## Summary
- Adds JSON-ready serialization for motion tracklets so candidates can be reviewed outside the algorithm layer.
- Adds an uncertainty-weighted review queue that combines motion score with coverage miss probability.
- Adds tests for serialization, uncertainty-first ranking, and missing-coverage defaults.

## Validation
- \python -m pytest\ - 65 passed.
- \python scripts\\verify_release.py\ - compile ok, unit tests ok, offline config ok, replay config ok, acceptance pipeline ok.

## Notes
- This is intentionally draft: review items are candidate artifacts, not confirmed person detections.
- Confirm/reject/uncertain persistence and UI wiring remain later slices.