### PR TITLE
[codex] Add review decision persistence

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,7 +24,7 @@ This roadmap is bold about direction and conservative about claims. Every new in
 - Add a detector comparison gate that refuses apples-to-oranges fine-tune claims.
 - Prototype coverage-confidence grid logic with synthetic planted-target mechanics/ranking validation; defer calibrated probability claims until fine-tuned recall inputs and held-out validation exist.
 - Add motion-first candidate tracklets from frame differencing or optical flow. First slice: synthetic-frame motion candidates and persistence-scored tracklets.
-- Add a review queue that ranks track-level candidates by uncertainty, motion, and detector evidence. First slice: JSON-ready motion records and uncertainty-weighted review ranking.
+- Add a review queue that ranks track-level candidates by uncertainty, motion, and detector evidence. First slices: JSON-ready motion records, uncertainty-weighted review ranking, and persisted reviewer decisions.
 - Keep SAR priors minimal at first: last known position, elapsed time, simple movement radius, and optional search-area polygon.
 
 ## Longer-term

--- a/docs/superpowers/specs/2026-07-01-review-decision-persistence-design.md
+++ b/docs/superpowers/specs/2026-07-01-review-decision-persistence-design.md
@@ -1,0 +1,62 @@
+# Review Decision Persistence Design
+
+## Purpose
+
+The review queue can now produce candidate records, but a human-in-the-loop workflow needs an audit trail of what reviewers did with those candidates. This slice adds a minimal persistence layer for review decisions so candidate review can survive process boundaries and later feed UI, metrics, and reviewer-reliability work.
+
+This is not a claim that a candidate is a person. A `confirmed` decision means a reviewer confirmed the candidate in the review workflow, not that SAR-INTEL produced ground truth.
+
+## Scope
+
+- Represent review decisions for motion/review candidates keyed by `tracklet_id`.
+- Support the statuses `confirmed`, `rejected`, and `uncertain`.
+- Store reviewer id, UTC decision timestamp, optional note, and optional confidence.
+- Serialize decisions to JSON-ready records.
+- Append decisions to a JSONL audit log and load them back.
+- Merge the latest decision for each tracklet into existing review queue records.
+
+## Out of Scope
+
+- User authentication or identity management.
+- Concurrent edit conflict resolution beyond append-log ordering by timestamp.
+- UI controls for confirm/reject/uncertain.
+- Treating reviewer decisions as operational truth.
+- Reviewer fatigue scoring, which should build on these persisted events later.
+
+## Data Model
+
+A review decision record has this shape:
+
+```json
+{
+  "tracklet_id": "motion-0001",
+  "status": "confirmed",
+  "reviewer": "operator-a",
+  "decided_at": "2026-07-01T18:30:00Z",
+  "note": "Visible moving person near tree line.",
+  "confidence": 0.82
+}
+```
+
+`note` and `confidence` are optional. Confidence is constrained to the `[0.0, 1.0]` interval.
+
+## Behavior
+
+`ReviewDecision` validates required fields and supported statuses when created. Serialization emits stable JSON-ready dictionaries with UTC timestamps ending in `Z`.
+
+`append_review_decision_jsonl` writes one decision per line, preserving an append-friendly audit trail. `load_review_decisions_jsonl` reads those records back into typed decisions.
+
+`apply_review_decisions` does not mutate the original queue. It copies queue records and overlays the latest decision by `tracklet_id`, setting the candidate status and embedding the review record under `review`.
+
+## Validation
+
+The test suite covers:
+
+- JSON-ready serialization.
+- unsupported status rejection.
+- confidence range validation.
+- latest-decision merge behavior.
+- append/load JSONL round-trip.
+- chronological serialization of a decision list.
+
+This validates the persistence mechanics. It does not validate reviewer correctness, review UX quality, or field reliability.

--- a/review_decisions.py
+++ b/review_decisions.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from os import PathLike
+from typing import Any, Iterable, Literal, Mapping
+
+ReviewStatus = Literal["confirmed", "rejected", "uncertain"]
+ReviewLogPath = str | PathLike[str]
+
+SUPPORTED_REVIEW_STATUSES: set[str] = {"confirmed", "rejected", "uncertain"}
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _format_timestamp(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _parse_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+@dataclass(frozen=True)
+class ReviewDecision:
+    tracklet_id: str
+    status: ReviewStatus
+    reviewer: str
+    decided_at: datetime = field(default_factory=_utc_now)
+    note: str | None = None
+    confidence: float | None = None
+
+    def __post_init__(self) -> None:
+        if not self.tracklet_id:
+            raise ValueError("tracklet_id is required")
+        if self.status not in SUPPORTED_REVIEW_STATUSES:
+            raise ValueError(f"Unsupported review status: {self.status}")
+        if not self.reviewer:
+            raise ValueError("reviewer is required")
+        if self.confidence is not None and not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be between 0.0 and 1.0")
+
+    def to_record(self) -> dict[str, Any]:
+        record: dict[str, Any] = {
+            "tracklet_id": self.tracklet_id,
+            "status": self.status,
+            "reviewer": self.reviewer,
+            "decided_at": _format_timestamp(self.decided_at),
+        }
+        if self.note is not None:
+            record["note"] = self.note
+        if self.confidence is not None:
+            record["confidence"] = self.confidence
+        return record
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, Any]) -> ReviewDecision:
+        return cls(
+            tracklet_id=str(record["tracklet_id"]),
+            status=record["status"],
+            reviewer=str(record["reviewer"]),
+            decided_at=_parse_timestamp(str(record["decided_at"])),
+            note=record.get("note"),
+            confidence=record.get("confidence"),
+        )
+
+
+def serialize_review_decisions(decisions: Iterable[ReviewDecision]) -> list[dict[str, Any]]:
+    return [decision.to_record() for decision in sorted(decisions, key=lambda item: item.decided_at)]
+
+
+def append_review_decision_jsonl(path: ReviewLogPath, decision: ReviewDecision) -> None:
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps(decision.to_record(), sort_keys=True))
+        handle.write("\n")
+
+
+def load_review_decisions_jsonl(path: ReviewLogPath) -> list[ReviewDecision]:
+    decisions: list[ReviewDecision] = []
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped:
+                decisions.append(ReviewDecision.from_record(json.loads(stripped)))
+    return decisions
+
+
+def apply_review_decisions(
+    queue: Iterable[Mapping[str, Any]],
+    decisions: Iterable[ReviewDecision],
+) -> list[dict[str, Any]]:
+    latest_by_tracklet: dict[str, ReviewDecision] = {}
+    for decision in decisions:
+        current = latest_by_tracklet.get(decision.tracklet_id)
+        if current is None or decision.decided_at >= current.decided_at:
+            latest_by_tracklet[decision.tracklet_id] = decision
+
+    merged: list[dict[str, Any]] = []
+    for item in queue:
+        record = dict(item)
+        decision = latest_by_tracklet.get(str(record.get("tracklet_id", "")))
+        if decision is not None:
+            record["status"] = decision.status
+            record["review"] = decision.to_record()
+        merged.append(record)
+    return merged

--- a/tests/test_review_decisions.py
+++ b/tests/test_review_decisions.py
@@ -1,0 +1,129 @@
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from review_decisions import (
+    ReviewDecision,
+    apply_review_decisions,
+    append_review_decision_jsonl,
+    load_review_decisions_jsonl,
+    serialize_review_decisions,
+)
+
+
+def test_review_decision_serializes_to_json_ready_record() -> None:
+    decided_at = datetime(2026, 7, 1, 18, 30, tzinfo=UTC)
+
+    decision = ReviewDecision(
+        tracklet_id="motion-0001",
+        status="confirmed",
+        reviewer="operator-a",
+        decided_at=decided_at,
+        note="Visible moving person near tree line.",
+        confidence=0.82,
+    )
+
+    assert decision.to_record() == {
+        "tracklet_id": "motion-0001",
+        "status": "confirmed",
+        "reviewer": "operator-a",
+        "decided_at": "2026-07-01T18:30:00Z",
+        "note": "Visible moving person near tree line.",
+        "confidence": 0.82,
+    }
+
+
+def test_review_decision_rejects_unknown_status() -> None:
+    with pytest.raises(ValueError, match="Unsupported review status"):
+        ReviewDecision(tracklet_id="motion-0001", status="maybe", reviewer="operator-a")
+
+
+def test_review_decision_rejects_confidence_outside_unit_interval() -> None:
+    with pytest.raises(ValueError, match="confidence"):
+        ReviewDecision(tracklet_id="motion-0001", status="confirmed", reviewer="operator-a", confidence=1.2)
+
+
+def test_apply_review_decisions_merges_latest_status_into_queue_records() -> None:
+    queue = [
+        {"tracklet_id": "motion-0001", "status": "unreviewed", "review_priority": 10.0},
+        {"tracklet_id": "motion-0002", "status": "unreviewed", "review_priority": 9.0},
+    ]
+    decisions = [
+        ReviewDecision(
+            tracklet_id="motion-0001",
+            status="uncertain",
+            reviewer="operator-a",
+            decided_at=datetime(2026, 7, 1, 18, 0, tzinfo=UTC),
+        ),
+        ReviewDecision(
+            tracklet_id="motion-0001",
+            status="confirmed",
+            reviewer="operator-b",
+            decided_at=datetime(2026, 7, 1, 18, 5, tzinfo=UTC),
+            confidence=0.7,
+        ),
+    ]
+
+    merged = apply_review_decisions(queue, decisions)
+
+    assert merged[0]["status"] == "confirmed"
+    assert merged[0]["review"] == {
+        "tracklet_id": "motion-0001",
+        "status": "confirmed",
+        "reviewer": "operator-b",
+        "decided_at": "2026-07-01T18:05:00Z",
+        "confidence": 0.7,
+    }
+    assert merged[1]["status"] == "unreviewed"
+    assert "review" not in merged[1]
+
+
+def test_serialize_review_decisions_orders_append_log_by_decision_time() -> None:
+    decisions = [
+        ReviewDecision(
+            tracklet_id="motion-0002",
+            status="rejected",
+            reviewer="operator-a",
+            decided_at=datetime(2026, 7, 1, 18, 10, tzinfo=UTC),
+        ),
+        ReviewDecision(
+            tracklet_id="motion-0001",
+            status="confirmed",
+            reviewer="operator-a",
+            decided_at=datetime(2026, 7, 1, 18, 0, tzinfo=UTC),
+        ),
+    ]
+
+    records = serialize_review_decisions(decisions)
+
+    assert [record["tracklet_id"] for record in records] == ["motion-0001", "motion-0002"]
+
+
+def test_review_decisions_append_and_load_jsonl_log(tmp_path: Path) -> None:
+    path = tmp_path / "review-decisions.jsonl"
+
+    append_review_decision_jsonl(
+        path,
+        ReviewDecision(
+            tracklet_id="motion-0001",
+            status="confirmed",
+            reviewer="operator-a",
+            decided_at=datetime(2026, 7, 1, 18, 0, tzinfo=UTC),
+            note="Clear movement.",
+        ),
+    )
+    append_review_decision_jsonl(
+        path,
+        ReviewDecision(
+            tracklet_id="motion-0002",
+            status="rejected",
+            reviewer="operator-a",
+            decided_at=datetime(2026, 7, 1, 18, 1, tzinfo=UTC),
+        ),
+    )
+
+    loaded = load_review_decisions_jsonl(path)
+
+    assert [decision.tracklet_id for decision in loaded] == ["motion-0001", "motion-0002"]
+    assert loaded[0].note == "Clear movement."


### PR DESCRIPTION
## Summary
- Adds typed reviewer decisions for review candidates with `confirmed`, `rejected`, and `uncertain` statuses.
- Adds JSON-ready serialization plus JSONL append/load helpers for an audit-friendly review log.
- Adds queue merge behavior so the latest reviewer decision can be overlaid onto candidate records without mutating the original queue.

## Validation
- `python -m pytest` - 71 passed.
- `python scripts\verify_release.py` - compile ok, unit tests ok, offline config ok, replay config ok, acceptance pipeline ok.

## Notes
- A confirmed review decision means a human reviewer confirmed the candidate in the review workflow; it is not claimed as operational ground truth.
- UI controls, reviewer fatigue modeling, and conflict handling remain follow-on slices.