### PR TITLE
[codex] Add public review cockpit

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,7 +24,7 @@ This roadmap is bold about direction and conservative about claims. Every new in
 - Add a detector comparison gate that refuses apples-to-oranges fine-tune claims.
 - Prototype coverage-confidence grid logic with synthetic planted-target mechanics/ranking validation; defer calibrated probability claims until fine-tuned recall inputs and held-out validation exist.
 - Add motion-first candidate tracklets from frame differencing or optical flow. First slice: synthetic-frame motion candidates and persistence-scored tracklets.
-- Add a review queue that ranks track-level candidates by uncertainty, motion, and detector evidence. First slices: JSON-ready motion records, uncertainty-weighted review ranking, and persisted reviewer decisions.
+- Add a review queue that ranks track-level candidates by uncertainty, motion, and detector evidence. First slices: JSON-ready motion records, uncertainty-weighted review ranking, persisted reviewer decisions, and a public review cockpit preview.
 - Keep SAR priors minimal at first: last known position, elapsed time, simple movement radius, and optional search-area polygon.
 
 ## Longer-term

--- a/docs/superpowers/specs/2026-07-02-public-review-cockpit-design.md
+++ b/docs/superpowers/specs/2026-07-02-public-review-cockpit-design.md
@@ -1,0 +1,35 @@
+# Public Review Cockpit Design
+
+## Purpose
+
+The project now has motion candidates, uncertainty-ranked review queues, and persisted reviewer decisions. The public site needs to show that product direction visually: not just a map of detections, but a human review cockpit where candidates, uncertainty, and decisions are visible together.
+
+This slice makes the audience understand the future product: SAR-INTEL is becoming a search-confidence and review workflow, not a magic detector.
+
+## Scope
+
+- Add a public-site review cockpit section.
+- Show a visual frame preview with a candidate box and motion trail.
+- Show an uncertainty-ranked candidate queue.
+- Show candidate details: motion score, coverage miss probability, review priority, location hint, and why the candidate was surfaced.
+- Add demo review actions: confirm candidate, mark uncertain, reject candidate.
+- Render an in-page decision log using the same vocabulary as the persisted review-decision module.
+
+## Boundaries
+
+- Browser decisions are demo state only.
+- This does not persist decisions to disk or GitHub Pages storage.
+- A confirmed candidate means reviewed in the demo workflow, not operational ground truth.
+- This is not field SAR software.
+
+## Interaction Model
+
+The user selects a candidate from the queue. The cockpit updates the frame preview, metadata, and action buttons. When the user records a decision, the candidate status changes and a decision-log event is added at the top of the log.
+
+The queue stays deliberately small in this slice so the interaction is legible and testable. Later slices can connect it to generated review queue JSON and real frame crops.
+
+## Validation
+
+The public-site hardening test checks that the cockpit exists, exposes candidate-review actions, and avoids operational overclaim language such as `victim found`.
+
+Manual browser verification should confirm that the cockpit renders on desktop and mobile, the buttons update status, and text does not overlap.

--- a/site/app.js
+++ b/site/app.js
@@ -433,3 +433,238 @@ fetchDemoGeoJson()
   .catch((error) => {
     renderErrorState(String(error));
   });
+const reviewCandidates = [
+  {
+    id: "motion-0007",
+    title: "Tree-line motion candidate",
+    frameRange: "frames 184-193",
+    status: "unreviewed",
+    priority: 14.6,
+    motionScore: 8.1,
+    missProbability: 0.65,
+    evidence: "Persistent small motion against a mostly static background.",
+    locationHint: "northwest grid cell",
+    bbox: { left: 28, top: 36, width: 22, height: 30 },
+    trail: [
+      { left: 30, top: 62 },
+      { left: 36, top: 58 },
+      { left: 43, top: 54 },
+    ],
+  },
+  {
+    id: "motion-0012",
+    title: "Ridge-path uncertainty candidate",
+    frameRange: "frames 241-249",
+    status: "unreviewed",
+    priority: 12.2,
+    motionScore: 6.7,
+    missProbability: 0.55,
+    evidence: "Lower motion score, but coverage confidence says this cell deserves another human look.",
+    locationHint: "ridge path edge",
+    bbox: { left: 56, top: 24, width: 18, height: 24 },
+    trail: [
+      { left: 58, top: 46 },
+      { left: 61, top: 43 },
+      { left: 65, top: 41 },
+    ],
+  },
+  {
+    id: "motion-0019",
+    title: "Open-field flicker candidate",
+    frameRange: "frames 318-322",
+    status: "unreviewed",
+    priority: 8.4,
+    motionScore: 5.9,
+    missProbability: 0.25,
+    evidence: "Short-lived motion that remains below confirmation threshold until reviewed.",
+    locationHint: "open field pass",
+    bbox: { left: 41, top: 52, width: 16, height: 20 },
+    trail: [
+      { left: 43, top: 70 },
+      { left: 47, top: 68 },
+      { left: 50, top: 66 },
+    ],
+  },
+];
+
+const reviewDecisionActions = [
+  { status: "confirmed", label: "Confirm candidate" },
+  { status: "uncertain", label: "Mark uncertain" },
+  { status: "rejected", label: "Reject candidate" },
+];
+
+let selectedReviewCandidateId = reviewCandidates[0]?.id || null;
+let reviewDecisionLog = [];
+
+function reviewStatusLabel(status) {
+  if (status === "confirmed") {
+    return "confirmed by reviewer";
+  }
+  if (status === "rejected") {
+    return "rejected by reviewer";
+  }
+  if (status === "uncertain") {
+    return "uncertain after review";
+  }
+  return "unreviewed";
+}
+
+function selectedReviewCandidate() {
+  return reviewCandidates.find((candidate) => candidate.id === selectedReviewCandidateId) || reviewCandidates[0];
+}
+
+function renderReviewStats() {
+  const container = document.getElementById("review-stat-grid");
+  if (!container) {
+    return;
+  }
+
+  container.innerHTML = "";
+  const counts = {
+    candidates: reviewCandidates.length,
+    unresolved: reviewCandidates.filter((candidate) => candidate.status === "unreviewed").length,
+    decisions: reviewDecisionLog.length,
+  };
+
+  for (const item of [
+    { label: "Candidates", value: counts.candidates },
+    { label: "Unresolved", value: counts.unresolved },
+    { label: "Decisions", value: counts.decisions },
+  ]) {
+    const card = document.createElement("article");
+    appendTextElement(card, "span", item.label);
+    appendTextElement(card, "strong", item.value);
+    container.appendChild(card);
+  }
+}
+
+function renderReviewCandidateList() {
+  const container = document.getElementById("review-candidate-list");
+  if (!container) {
+    return;
+  }
+
+  container.innerHTML = "";
+  for (const candidate of reviewCandidates) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = candidate.id === selectedReviewCandidateId ? "review-candidate is-active" : "review-candidate";
+    button.addEventListener("click", () => {
+      selectedReviewCandidateId = candidate.id;
+      renderReviewCockpit();
+    });
+
+    const heading = document.createElement("span");
+    heading.className = "review-candidate-title";
+    heading.textContent = candidate.title;
+    button.appendChild(heading);
+
+    const meta = document.createElement("span");
+    meta.className = "review-candidate-meta";
+    meta.textContent = `${candidate.id} · priority ${candidate.priority.toFixed(1)} · ${reviewStatusLabel(candidate.status)}`;
+    button.appendChild(meta);
+
+    container.appendChild(button);
+  }
+}
+
+function renderReviewFrame(candidate) {
+  const title = document.getElementById("review-frame-title");
+  const status = document.getElementById("review-frame-status");
+  const box = document.getElementById("review-candidate-box");
+  const trail = document.getElementById("review-motion-trail");
+  const details = document.getElementById("review-details");
+
+  if (title) {
+    title.textContent = `${candidate.title} · ${candidate.frameRange}`;
+  }
+  if (status) {
+    status.textContent = reviewStatusLabel(candidate.status);
+    status.dataset.status = candidate.status;
+  }
+  if (box) {
+    box.style.left = `${candidate.bbox.left}%`;
+    box.style.top = `${candidate.bbox.top}%`;
+    box.style.width = `${candidate.bbox.width}%`;
+    box.style.height = `${candidate.bbox.height}%`;
+    box.textContent = candidate.id;
+  }
+  if (trail) {
+    trail.innerHTML = "";
+    for (const point of candidate.trail) {
+      const dot = document.createElement("span");
+      dot.style.left = `${point.left}%`;
+      dot.style.top = `${point.top}%`;
+      trail.appendChild(dot);
+    }
+  }
+  if (details) {
+    details.innerHTML = "";
+    appendDefinition(details, "Motion score", candidate.motionScore.toFixed(1));
+    appendDefinition(details, "Coverage miss probability", candidate.missProbability.toFixed(2));
+    appendDefinition(details, "Review priority", candidate.priority.toFixed(1));
+    appendDefinition(details, "Location hint", candidate.locationHint);
+    appendDefinition(details, "Why surfaced", candidate.evidence);
+  }
+}
+
+function renderReviewActions(candidate) {
+  const container = document.getElementById("review-actions");
+  if (!container) {
+    return;
+  }
+
+  container.innerHTML = "";
+  for (const action of reviewDecisionActions) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `review-action review-action-${action.status}`;
+    button.textContent = action.label;
+    button.addEventListener("click", () => {
+      candidate.status = action.status;
+      reviewDecisionLog.unshift({
+        trackletId: candidate.id,
+        status: action.status,
+        reviewer: "public-demo-reviewer",
+        decidedAt: new Date().toISOString(),
+      });
+      renderReviewCockpit();
+    });
+    container.appendChild(button);
+  }
+}
+
+function renderReviewLog() {
+  const container = document.getElementById("review-log");
+  if (!container) {
+    return;
+  }
+
+  container.innerHTML = "";
+  if (reviewDecisionLog.length === 0) {
+    appendTextElement(container, "p", "No demo decisions yet. Select a candidate and record a review action.");
+    return;
+  }
+
+  for (const decision of reviewDecisionLog.slice(0, 5)) {
+    const item = document.createElement("article");
+    appendTextElement(item, "strong", `${decision.trackletId}: ${reviewStatusLabel(decision.status)}`);
+    appendTextElement(item, "span", `${decision.reviewer} · ${decision.decidedAt}`);
+    container.appendChild(item);
+  }
+}
+
+function renderReviewCockpit() {
+  const candidate = selectedReviewCandidate();
+  if (!candidate) {
+    return;
+  }
+
+  renderReviewStats();
+  renderReviewCandidateList();
+  renderReviewFrame(candidate);
+  renderReviewActions(candidate);
+  renderReviewLog();
+}
+
+renderReviewCockpit();

--- a/site/index.html
+++ b/site/index.html
@@ -183,6 +183,45 @@
       </div>
     </section>
 
+
+    <section class="panel review-cockpit-panel" id="review">
+      <div class="review-copy">
+        <p class="section-tag">Human review cockpit</p>
+        <h2>Candidate review, uncertainty, and human decisions in one screen.</h2>
+        <p>
+          The next SAR-INTEL interface is not just a detector output. It is a human review cockpit: motion candidates, coverage uncertainty, and reviewer decisions stay visible together so the operator can move fast without pretending the system is certain.
+        </p>
+        <p class="review-note">
+          Demo-only state. These are review candidates, not confirmed people, and browser decisions are a public-site preview of the persisted review-decision workflow.
+        </p>
+      </div>
+      <div class="review-workspace" aria-label="Human review cockpit demo">
+        <div class="review-frame-panel">
+          <div class="review-frame-head">
+            <span id="review-frame-title">Candidate frame</span>
+            <strong id="review-frame-status">unreviewed</strong>
+          </div>
+          <div class="review-frame" id="review-frame" aria-label="Candidate frame preview">
+            <span class="review-scanline"></span>
+            <div class="review-candidate-box" id="review-candidate-box"></div>
+            <div class="review-motion-trail" id="review-motion-trail"></div>
+          </div>
+          <dl class="review-details" id="review-details"></dl>
+          <div class="review-actions" id="review-actions" aria-label="Review decision actions"></div>
+        </div>
+        <aside class="review-queue-panel">
+          <div class="review-stat-grid" id="review-stat-grid"></div>
+          <div>
+            <h3>candidate queue</h3>
+            <div class="review-candidate-list" id="review-candidate-list"></div>
+          </div>
+          <div>
+            <h3>Decision log</h3>
+            <div class="review-log" id="review-log"></div>
+          </div>
+        </aside>
+      </div>
+    </section>
     <section class="panel map-panel" id="demo">
       <div class="map-copy">
         <p class="section-tag">Map-ready GeoJSON</p>

--- a/site/styles.css
+++ b/site/styles.css
@@ -857,6 +857,8 @@ h3 {
 }
 
 @media (max-width: 960px) {
+  .review-cockpit-panel,
+  .review-workspace,
   .story-strip,
   .visual-proof-panel,
   .report-panel {
@@ -893,6 +895,9 @@ h3 {
 }
 
 @media (max-width: 680px) {
+  .review-actions,
+  .review-details,
+  .review-stat-grid,
   .story-strip,
   .visual-proof-panel,
   .report-panel {
@@ -978,5 +983,325 @@ h3 {
 
   #map {
     min-height: 420px;
+  }
+}
+
+.review-cockpit-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 0.75fr) minmax(0, 1.25fr);
+  gap: 28px;
+  align-items: start;
+}
+
+.review-copy p:not(.section-tag),
+.review-note {
+  color: var(--muted);
+}
+
+.review-note {
+  margin: 18px 0 0;
+  padding: 14px 16px;
+  border-left: 3px solid var(--coral);
+  background: rgba(255, 255, 255, 0.06);
+  line-height: 1.5;
+}
+
+.review-workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1.12fr) minmax(300px, 0.88fr);
+  gap: 16px;
+}
+
+.review-frame-panel,
+.review-queue-panel {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(6, 14, 25, 0.78);
+}
+
+.review-frame-panel {
+  padding: 18px;
+}
+
+.review-queue-panel {
+  display: grid;
+  gap: 18px;
+  padding: 16px;
+}
+
+.review-frame-head {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.review-frame-head span,
+.review-frame-head strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.review-frame-head span {
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.review-frame-head strong {
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(184, 243, 107, 0.3);
+  color: var(--signal);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.review-frame-head strong[data-status="confirmed"] {
+  border-color: rgba(184, 243, 107, 0.5);
+  background: rgba(184, 243, 107, 0.14);
+}
+
+.review-frame-head strong[data-status="uncertain"] {
+  border-color: rgba(255, 143, 112, 0.5);
+  color: var(--coral);
+  background: rgba(255, 143, 112, 0.13);
+}
+
+.review-frame-head strong[data-status="rejected"] {
+  border-color: rgba(159, 178, 200, 0.36);
+  color: var(--muted);
+  background: rgba(159, 178, 200, 0.1);
+}
+
+.review-frame {
+  position: relative;
+  min-height: 370px;
+  overflow: hidden;
+  border: 1px solid rgba(94, 227, 255, 0.22);
+  border-radius: 8px;
+  background:
+    linear-gradient(rgba(94, 227, 255, 0.07) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(94, 227, 255, 0.07) 1px, transparent 1px),
+    radial-gradient(circle at 30% 45%, rgba(184, 243, 107, 0.12), transparent 22%),
+    linear-gradient(135deg, #172c45, #07111f 58%, #13263a);
+  background-size: 32px 32px, 32px 32px, auto, auto;
+}
+
+.review-scanline {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 48%;
+  height: 2px;
+  background: var(--cyan);
+  box-shadow: 0 0 22px rgba(94, 227, 255, 0.85);
+}
+
+.review-candidate-box {
+  position: absolute;
+  display: grid;
+  place-items: end start;
+  padding: 8px;
+  border: 2px solid var(--signal);
+  color: var(--ink);
+  background: rgba(8, 17, 31, 0.55);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.76rem;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.review-motion-trail span {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--coral);
+  box-shadow: 0 0 16px rgba(255, 143, 112, 0.72);
+}
+
+.review-details {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  margin: 14px 0 0;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(234, 243, 255, 0.12);
+}
+
+.review-details div {
+  min-width: 0;
+  padding: 12px;
+  background: rgba(8, 17, 31, 0.58);
+}
+
+.review-details dt {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.review-details dd {
+  margin: 5px 0 0;
+  color: var(--ink);
+  overflow-wrap: anywhere;
+}
+
+.review-actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.review-action,
+.review-candidate {
+  max-width: 100%;
+  border: 1px solid rgba(94, 227, 255, 0.24);
+  border-radius: 8px;
+  font-family: inherit;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+}
+
+.review-action {
+  min-height: 46px;
+  padding: 10px 12px;
+  color: var(--ink);
+  background: rgba(255, 255, 255, 0.08);
+  font-weight: 700;
+}
+
+.review-action-confirmed {
+  border-color: rgba(184, 243, 107, 0.5);
+}
+
+.review-action-uncertain {
+  border-color: rgba(255, 143, 112, 0.5);
+}
+
+.review-action-rejected {
+  border-color: rgba(159, 178, 200, 0.42);
+}
+
+.review-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.review-stat-grid article {
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.review-stat-grid span {
+  display: block;
+  color: var(--muted);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.review-stat-grid strong {
+  display: block;
+  margin-top: 6px;
+  color: var(--paper-strong);
+  font-size: 1.4rem;
+}
+
+.review-queue-panel h3 {
+  margin-bottom: 10px;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.review-candidate-list,
+.review-log {
+  display: grid;
+  gap: 10px;
+}
+
+.review-candidate {
+  display: grid;
+  gap: 6px;
+  width: 100%;
+  padding: 12px;
+  text-align: left;
+  color: var(--ink);
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.review-candidate.is-active {
+  border-color: var(--cyan);
+  background: rgba(94, 227, 255, 0.13);
+}
+
+.review-candidate-title {
+  font-weight: 700;
+}
+
+.review-candidate-meta {
+  color: var(--muted);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
+.review-log p,
+.review-log article {
+  margin: 0;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--muted);
+}
+
+.review-log strong,
+.review-log span {
+  display: block;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.review-log strong {
+  color: var(--ink);
+}
+
+.review-log span {
+  margin-top: 5px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.78rem;
+}
+@media (max-width: 960px) {
+  .review-cockpit-panel,
+  .review-workspace {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 680px) {
+  .review-actions,
+  .review-details,
+  .review-stat-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .review-frame {
+    min-height: 320px;
   }
 }

--- a/tests/test_public_site_hardening.py
+++ b/tests/test_public_site_hardening.py
@@ -24,3 +24,16 @@ def test_public_site_keeps_simulation_first_framing_in_hero() -> None:
     index_html = (ROOT / "site" / "index.html").read_text(encoding="utf-8")
 
     assert "Simulation-first humanitarian SAR intelligence" in index_html
+
+
+def test_public_site_exposes_review_cockpit_without_operational_overclaim() -> None:
+    index_html = (ROOT / "site" / "index.html").read_text(encoding="utf-8")
+    app_js = (ROOT / "site" / "app.js").read_text(encoding="utf-8")
+
+    assert "Human review cockpit" in index_html
+    assert "candidate queue" in index_html
+    assert "Confirm candidate" in app_js
+    assert "Mark uncertain" in app_js
+    assert "Reject candidate" in app_js
+    assert "victim found" not in index_html.lower()
+    assert "victim found" not in app_js.lower()


### PR DESCRIPTION
## Summary
- Adds a public-site human review cockpit preview with a visual frame panel, motion trail, candidate queue, uncertainty details, and review actions.
- Adds demo interaction state for confirm / uncertain / reject decisions and an in-page decision log using the persisted review-decision vocabulary.
- Adds a design spec, roadmap update, and hardening coverage that checks review language while avoiding operational overclaim wording.

## Validation
- `node --check site\app.js` - passed.
- `python -m pytest tests\test_public_site_hardening.py` - 4 passed.
- `python -m pytest` - 72 passed.
- `python scripts\verify_release.py` - compile ok, unit tests ok, offline config ok, replay config ok, acceptance pipeline ok.
- Playwright visual/interaction pass on `http://127.0.0.1:8013/#review`: cockpit rendered, `Confirm candidate` updated status/log, desktop/mobile layout had no horizontal overflow.

## Notes
- Browser decisions are public-demo state only; they do not persist to disk or GitHub Pages storage.
- A confirmed candidate means confirmed in the demo review workflow, not operational ground truth.