### PR TITLE
[codex] Add public review queue asset

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,7 +24,7 @@ This roadmap is bold about direction and conservative about claims. Every new in
 - Add a detector comparison gate that refuses apples-to-oranges fine-tune claims.
 - Prototype coverage-confidence grid logic with synthetic planted-target mechanics/ranking validation; defer calibrated probability claims until fine-tuned recall inputs and held-out validation exist.
 - Add motion-first candidate tracklets from frame differencing or optical flow. First slice: synthetic-frame motion candidates and persistence-scored tracklets.
-- Add a review queue that ranks track-level candidates by uncertainty, motion, and detector evidence. First slices: JSON-ready motion records, uncertainty-weighted review ranking, persisted reviewer decisions, and a public review cockpit preview.
+- Add a review queue that ranks track-level candidates by uncertainty, motion, and detector evidence. First slices: JSON-ready motion records, uncertainty-weighted review ranking, persisted reviewer decisions, a public review cockpit preview, and a public-safe review queue asset.
 - Keep SAR priors minimal at first: last known position, elapsed time, simple movement radius, and optional search-area polygon.
 
 ## Longer-term

--- a/docs/superpowers/specs/2026-07-02-public-review-queue-asset-design.md
+++ b/docs/superpowers/specs/2026-07-02-public-review-queue-asset-design.md
@@ -1,0 +1,24 @@
+# Public Review Queue Asset Design
+
+## Purpose
+
+The public review cockpit should demonstrate the project architecture, not only a hand-coded interface. This slice moves the cockpit candidate queue into a public-safe JSON asset that can be regenerated and checked by tests.
+
+The goal is to make the public demo feel like a real artifact pipeline: generated review candidates feed the cockpit, reviewer actions remain browser-demo state, and the safety boundary stays explicit.
+
+## Scope
+
+- Add `site/assets/review_queue.json` as a sanitized public demo asset.
+- Add `scripts/build_public_review_queue.py` to generate and check that asset deterministically.
+- Update `site/app.js` to fetch `assets/review_queue.json`, normalize its snake_case records into the cockpit view model, and fall back to embedded demo candidates if loading fails.
+- Add tests that verify the asset is current, public-safe, review-ready, and referenced by the site.
+
+## Public Safety Boundary
+
+The asset contains no original mission coordinates, GPS fields, latitude/longitude fields, or operational incident context. It uses review-candidate identifiers, frame ranges, normalized frame-preview percentages, motion score, coverage miss probability, and review priority.
+
+A candidate is still a candidate. The public cockpit does not claim that any record is a person or a field-ready SAR finding.
+
+## Validation
+
+The test suite checks that `scripts/build_public_review_queue.py --check` matches the committed asset, that candidates are sorted by review priority, that frame-preview geometry is bounded to percentages, and that the public site loads the asset before fallback state.

--- a/scripts/build_public_review_queue.py
+++ b/scripts/build_public_review_queue.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+ASSET_PATH = ROOT / "site" / "assets" / "review_queue.json"
+
+CANDIDATES: list[dict[str, Any]] = [
+    {
+        "tracklet_id": "motion-0007",
+        "title": "Tree-line motion candidate",
+        "frame_range": "frames 184-193",
+        "status": "unreviewed",
+        "review_priority": 14.6,
+        "motion_score": 8.1,
+        "coverage_miss_probability": 0.65,
+        "evidence": "Persistent small motion against a mostly static background.",
+        "location_hint": "northwest grid cell",
+        "frame_preview": {
+            "bbox_percent": {"left": 28, "top": 36, "width": 22, "height": 30},
+            "motion_trail_percent": [
+                {"left": 30, "top": 62},
+                {"left": 36, "top": 58},
+                {"left": 43, "top": 54},
+            ],
+        },
+    },
+    {
+        "tracklet_id": "motion-0012",
+        "title": "Ridge-path uncertainty candidate",
+        "frame_range": "frames 241-249",
+        "status": "unreviewed",
+        "review_priority": 12.2,
+        "motion_score": 6.7,
+        "coverage_miss_probability": 0.55,
+        "evidence": "Lower motion score, but coverage confidence says this cell deserves another human look.",
+        "location_hint": "ridge path edge",
+        "frame_preview": {
+            "bbox_percent": {"left": 56, "top": 24, "width": 18, "height": 24},
+            "motion_trail_percent": [
+                {"left": 58, "top": 46},
+                {"left": 61, "top": 43},
+                {"left": 65, "top": 41},
+            ],
+        },
+    },
+    {
+        "tracklet_id": "motion-0019",
+        "title": "Open-field flicker candidate",
+        "frame_range": "frames 318-322",
+        "status": "unreviewed",
+        "review_priority": 8.4,
+        "motion_score": 5.9,
+        "coverage_miss_probability": 0.25,
+        "evidence": "Short-lived motion that remains below confirmation threshold until reviewed.",
+        "location_hint": "open field pass",
+        "frame_preview": {
+            "bbox_percent": {"left": 41, "top": 52, "width": 16, "height": 20},
+            "motion_trail_percent": [
+                {"left": 43, "top": 70},
+                {"left": 47, "top": 68},
+                {"left": 50, "top": 66},
+            ],
+        },
+    },
+]
+
+
+def build_payload() -> dict[str, Any]:
+    candidates = sorted(CANDIDATES, key=lambda item: float(item["review_priority"]), reverse=True)
+    return {
+        "type": "sar-intel-public-review-queue",
+        "version": 1,
+        "generated_from": "scripts/build_public_review_queue.py",
+        "source": "sanitized static public demo",
+        "safety_note": (
+            "Public demo review candidates only. These records do not identify people, do not include original "
+            "mission coordinates, and are not operational SAR findings."
+        ),
+        "candidates": candidates,
+    }
+
+
+def canonical_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def write_asset(path: Path = ASSET_PATH) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(canonical_json(build_payload()), encoding="utf-8")
+
+
+def check_asset(path: Path = ASSET_PATH) -> bool:
+    expected = canonical_json(build_payload())
+    if not path.exists():
+        print(f"Missing public review queue asset: {path}")
+        return False
+    actual = path.read_text(encoding="utf-8")
+    if actual != expected:
+        print(f"Public review queue asset is out of date: {path}")
+        return False
+    print(f"Public review queue asset is up to date: {path}")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build or check the public-safe review queue demo asset.")
+    parser.add_argument("--check", action="store_true", help="verify the committed asset matches this generator")
+    args = parser.parse_args()
+
+    if args.check:
+        return 0 if check_asset() else 1
+
+    write_asset()
+    print(f"Wrote public review queue asset: {ASSET_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/app.js
+++ b/site/app.js
@@ -433,7 +433,7 @@ fetchDemoGeoJson()
   .catch((error) => {
     renderErrorState(String(error));
   });
-const reviewCandidates = [
+const fallbackReviewCandidates = [
   {
     id: "motion-0007",
     title: "Tree-line motion candidate",
@@ -493,9 +493,63 @@ const reviewDecisionActions = [
   { status: "rejected", label: "Reject candidate" },
 ];
 
+let reviewCandidates = [...fallbackReviewCandidates];
 let selectedReviewCandidateId = reviewCandidates[0]?.id || null;
 let reviewDecisionLog = [];
 
+function fetchPublicReviewQueue() {
+  return fetch("assets/review_queue.json").then((response) => {
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    return response.json();
+  });
+}
+
+function normalizeReviewQueueCandidate(candidate) {
+  const preview = candidate.frame_preview || {};
+  return {
+    id: candidate.tracklet_id,
+    title: candidate.title,
+    frameRange: candidate.frame_range,
+    status: candidate.status || "unreviewed",
+    priority: Number(candidate.review_priority || 0),
+    motionScore: Number(candidate.motion_score || 0),
+    missProbability: Number(candidate.coverage_miss_probability || 0),
+    evidence: candidate.evidence,
+    locationHint: candidate.location_hint,
+    bbox: preview.bbox_percent || { left: 40, top: 40, width: 18, height: 24 },
+    trail: Array.isArray(preview.motion_trail_percent) ? preview.motion_trail_percent : [],
+  };
+}
+
+function applyReviewQueuePayload(payload) {
+  const candidates = Array.isArray(payload?.candidates)
+    ? payload.candidates.map(normalizeReviewQueueCandidate).filter((candidate) => candidate.id)
+    : [];
+
+  if (candidates.length === 0) {
+    return false;
+  }
+
+  reviewCandidates = candidates;
+  selectedReviewCandidateId = reviewCandidates[0].id;
+  reviewDecisionLog = [];
+  renderReviewCockpit();
+  return true;
+}
+
+function loadPublicReviewQueue() {
+  fetchPublicReviewQueue()
+    .then((payload) => {
+      if (!applyReviewQueuePayload(payload)) {
+        renderReviewCockpit();
+      }
+    })
+    .catch(() => {
+      renderReviewCockpit();
+    });
+}
 function reviewStatusLabel(status) {
   if (status === "confirmed") {
     return "confirmed by reviewer";
@@ -667,4 +721,4 @@ function renderReviewCockpit() {
   renderReviewLog();
 }
 
-renderReviewCockpit();
+loadPublicReviewQueue();

--- a/site/assets/review_queue.json
+++ b/site/assets/review_queue.json
@@ -1,0 +1,108 @@
+{
+  "candidates": [
+    {
+      "coverage_miss_probability": 0.65,
+      "evidence": "Persistent small motion against a mostly static background.",
+      "frame_preview": {
+        "bbox_percent": {
+          "height": 30,
+          "left": 28,
+          "top": 36,
+          "width": 22
+        },
+        "motion_trail_percent": [
+          {
+            "left": 30,
+            "top": 62
+          },
+          {
+            "left": 36,
+            "top": 58
+          },
+          {
+            "left": 43,
+            "top": 54
+          }
+        ]
+      },
+      "frame_range": "frames 184-193",
+      "location_hint": "northwest grid cell",
+      "motion_score": 8.1,
+      "review_priority": 14.6,
+      "status": "unreviewed",
+      "title": "Tree-line motion candidate",
+      "tracklet_id": "motion-0007"
+    },
+    {
+      "coverage_miss_probability": 0.55,
+      "evidence": "Lower motion score, but coverage confidence says this cell deserves another human look.",
+      "frame_preview": {
+        "bbox_percent": {
+          "height": 24,
+          "left": 56,
+          "top": 24,
+          "width": 18
+        },
+        "motion_trail_percent": [
+          {
+            "left": 58,
+            "top": 46
+          },
+          {
+            "left": 61,
+            "top": 43
+          },
+          {
+            "left": 65,
+            "top": 41
+          }
+        ]
+      },
+      "frame_range": "frames 241-249",
+      "location_hint": "ridge path edge",
+      "motion_score": 6.7,
+      "review_priority": 12.2,
+      "status": "unreviewed",
+      "title": "Ridge-path uncertainty candidate",
+      "tracklet_id": "motion-0012"
+    },
+    {
+      "coverage_miss_probability": 0.25,
+      "evidence": "Short-lived motion that remains below confirmation threshold until reviewed.",
+      "frame_preview": {
+        "bbox_percent": {
+          "height": 20,
+          "left": 41,
+          "top": 52,
+          "width": 16
+        },
+        "motion_trail_percent": [
+          {
+            "left": 43,
+            "top": 70
+          },
+          {
+            "left": 47,
+            "top": 68
+          },
+          {
+            "left": 50,
+            "top": 66
+          }
+        ]
+      },
+      "frame_range": "frames 318-322",
+      "location_hint": "open field pass",
+      "motion_score": 5.9,
+      "review_priority": 8.4,
+      "status": "unreviewed",
+      "title": "Open-field flicker candidate",
+      "tracklet_id": "motion-0019"
+    }
+  ],
+  "generated_from": "scripts/build_public_review_queue.py",
+  "safety_note": "Public demo review candidates only. These records do not identify people, do not include original mission coordinates, and are not operational SAR findings.",
+  "source": "sanitized static public demo",
+  "type": "sar-intel-public-review-queue",
+  "version": 1
+}

--- a/tests/test_public_review_queue_asset.py
+++ b/tests/test_public_review_queue_asset.py
@@ -1,0 +1,57 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ASSET_PATH = ROOT / "site" / "assets" / "review_queue.json"
+
+
+def test_public_review_queue_asset_matches_generator() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/build_public_review_queue.py", "--check"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_public_review_queue_asset_is_public_safe_and_review_ready() -> None:
+    payload = json.loads(ASSET_PATH.read_text(encoding="utf-8"))
+
+    assert payload["type"] == "sar-intel-public-review-queue"
+    assert payload["version"] == 1
+    assert payload["safety_note"]
+    assert len(payload["candidates"]) >= 3
+
+    priorities = [candidate["review_priority"] for candidate in payload["candidates"]]
+    assert priorities == sorted(priorities, reverse=True)
+
+    forbidden_keys = {"lat", "latitude", "lon", "longitude", "gps", "coordinates"}
+    serialized = json.dumps(payload).lower()
+    for key in forbidden_keys:
+        assert f'"{key}"' not in serialized
+
+    for candidate in payload["candidates"]:
+        assert candidate["tracklet_id"].startswith("motion-")
+        assert candidate["status"] == "unreviewed"
+        assert 0.0 <= candidate["coverage_miss_probability"] <= 1.0
+        assert candidate["motion_score"] >= 0.0
+        preview = candidate["frame_preview"]
+        bbox = preview["bbox_percent"]
+        assert set(bbox) == {"left", "top", "width", "height"}
+        assert all(0 <= bbox[name] <= 100 for name in bbox)
+        assert preview["motion_trail_percent"]
+
+
+def test_public_site_fetches_review_queue_asset_before_fallback() -> None:
+    app_js = (ROOT / "site" / "app.js").read_text(encoding="utf-8")
+
+    assert "assets/review_queue.json" in app_js
+    assert "fetchPublicReviewQueue" in app_js
+    assert "normalizeReviewQueueCandidate" in app_js
+    assert "fallbackReviewCandidates" in app_js

--- a/tests/test_public_site_hardening.py
+++ b/tests/test_public_site_hardening.py
@@ -35,5 +35,6 @@ def test_public_site_exposes_review_cockpit_without_operational_overclaim() -> N
     assert "Confirm candidate" in app_js
     assert "Mark uncertain" in app_js
     assert "Reject candidate" in app_js
+    assert "assets/review_queue.json" in app_js
     assert "victim found" not in index_html.lower()
     assert "victim found" not in app_js.lower()


### PR DESCRIPTION
## Summary
- Adds a deterministic public-safe `site/assets/review_queue.json` demo asset and generator/check script.
- Updates the public review cockpit to fetch `assets/review_queue.json`, normalize the records, and fall back to embedded demo candidates if loading fails.
- Adds tests for asset freshness, public-safety fields, priority ordering, site asset loading, and roadmap/spec documentation.

## Validation
- `python -m pytest tests\test_public_review_queue_asset.py tests\test_public_site_hardening.py` - 7 passed.
- `python scripts\build_public_review_queue.py --check` - asset up to date.
- `node --check site\app.js` - passed.
- `python -m pytest` - 75 passed.
- `python scripts\verify_release.py` - compile ok, unit tests ok, offline config ok, replay config ok, acceptance pipeline ok.
- Playwright browser pass on `http://127.0.0.1:8014/#review`: `assets/review_queue.json` requested, 3 candidates rendered, no horizontal overflow, `Mark uncertain` updated status/log.

## Notes
- The asset intentionally contains no original mission coordinates, GPS fields, latitude/longitude fields, or operational incident context.
- Review records are public demo candidates only; they are not operational SAR findings.