### PR TITLE
[codex] Add aerial fine-tune report gate

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,6 +18,7 @@ This roadmap is bold about direction and conservative about claims. Every new in
 - Landing page with GeoJSON demo
 - SHA256-pinned VisDrone validation manifests
 - Fixed-threshold AP / PR-curve reporting for detector comparisons
+- Fine-tune report gate for publish/no-publish aerial recall claims
 
 ## Near-term
 

--- a/docs/TRAINING_VISDRONE.md
+++ b/docs/TRAINING_VISDRONE.md
@@ -84,4 +84,18 @@ python scripts/evaluate_visdrone_det.py \
 
 Treat `output/visdrone_det_val_manifest.json` as part of the benchmark definition. If the manifest checksum changes, the run is a new benchmark and should not be compared directly with the published baseline.
 
-A fine-tuned model should only be described as improved when recall improves at fixed thresholds without an unacceptable precision collapse, and average precision / PR-curve behavior also improves on the same pinned manifest.
+## Build the fine-tune report gate
+
+After the baseline and candidate sweeps are produced on the same pinned manifest, build the publishable gate report:
+
+```bash
+python scripts/report_visdrone_finetune.py \
+  --baseline output/visdrone_det_sweep.json \
+  --candidate output/visdrone_det_finetuned_sweep.json \
+  --training-metadata output/visdrone_training_metadata.json \
+  --output output/visdrone_finetune_report.json
+```
+
+The command exits non-zero unless the candidate passes the same-manifest, fixed-threshold recall, precision-ratio, and average-precision gates. Use `--always-zero` only for exploratory local report generation, not for publishing an improvement claim.
+
+A fine-tuned model should only be described as improved when this report sets `claim.allowed` to `true`. Until then, the public detector remains the pre-fine-tune baseline.

--- a/docs/VISDRONE_VALIDATION.md
+++ b/docs/VISDRONE_VALIDATION.md
@@ -209,6 +209,18 @@ python scripts/compare_visdrone_runs.py \
 
 A candidate detector should not be described as improved unless this gate passes on the same validation manifest. The gate requires matching manifest checksums, recall improvement at matching fixed thresholds, no unacceptable precision collapse, and average-precision improvement. This protects the project from accidental split drift and from threshold-shopping that makes recall look better while the detector becomes less useful.
 
+For a publishable summary, generate the fine-tune report:
+
+```bash
+python scripts/report_visdrone_finetune.py \
+  --baseline output/visdrone_det_sweep.json \
+  --candidate output/visdrone_det_finetuned_sweep.json \
+  --training-metadata output/visdrone_training_metadata.json \
+  --output output/visdrone_finetune_report.json
+```
+
+Only a report with `claim.allowed: true` supports language that the candidate detector improved aerial-person recall. A failed report is still useful: it records exactly which gate blocked the claim.
+
 ## How To Improve This Later
 
 - Fine-tune the detector on aerial-person data, including VisDrone-like viewpoints and object scales.

--- a/docs/superpowers/plans/2026-07-02-aerial-finetune-report-gate.md
+++ b/docs/superpowers/plans/2026-07-02-aerial-finetune-report-gate.md
@@ -1,0 +1,69 @@
+# Aerial Fine-Tune Report Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a reproducible report gate that decides whether a fine-tuned aerial-person detector can honestly be described as improved.
+
+**Architecture:** Keep `compare_visdrone_runs.py` as the metric authority and add `scripts/report_visdrone_finetune.py` as an orchestration/reporting layer. The report layer wraps comparison results with claim language, validation provenance, gate settings, and optional training metadata.
+
+**Tech Stack:** Python stdlib, existing JSON sweep outputs, pytest, existing VisDrone evaluator/comparison scripts.
+
+---
+
+### Task 1: Report Gate Tests
+
+**Files:**
+- Create: `tests/test_report_visdrone_finetune.py`
+
+- [x] **Step 1: Write failing tests**
+
+Add tests for a passing candidate, a failed precision gate, and CLI non-zero behavior when the gate fails.
+
+- [x] **Step 2: Verify red**
+
+Run: `python -m pytest tests\test_report_visdrone_finetune.py -q`
+
+Expected: FAIL because `scripts/report_visdrone_finetune.py` does not exist.
+
+### Task 2: Report Gate Implementation
+
+**Files:**
+- Create: `scripts/report_visdrone_finetune.py`
+- Modify: `docs/TRAINING_VISDRONE.md`
+- Modify: `docs/VISDRONE_VALIDATION.md`
+- Modify: `docs/ROADMAP.md`
+
+- [x] **Step 1: Implement report builder**
+
+Create `build_finetune_report()` that calls `compare_runs()` and emits `type`, `version`, `verdict`, `claim`, `gates`, `validation`, `training`, and `comparison` fields.
+
+- [x] **Step 2: Implement CLI**
+
+Add `--baseline`, `--candidate`, `--training-metadata`, `--output`, `--recall-delta`, `--min-precision-ratio`, `--ap-delta`, and `--always-zero`.
+
+- [x] **Step 3: Verify green**
+
+Run: `python -m pytest tests\test_report_visdrone_finetune.py -q`
+
+Expected: PASS.
+
+### Task 3: Full Verification And Merge
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Run focused checks**
+
+Run: `python -m pytest tests\test_report_visdrone_finetune.py tests\test_compare_visdrone_runs.py -q`
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `python -m pytest`
+
+- [ ] **Step 3: Run release verification**
+
+Run: `python scripts\verify_release.py`
+
+- [ ] **Step 4: Commit, push, PR, and merge after CI**
+
+Commit the feature branch, push it, create a PR, wait for GitHub Actions, and merge only after checks pass.

--- a/docs/superpowers/specs/2026-07-02-aerial-finetune-report-gate-design.md
+++ b/docs/superpowers/specs/2026-07-02-aerial-finetune-report-gate-design.md
@@ -1,0 +1,19 @@
+# Aerial Fine-Tune Report Gate Design
+
+## Purpose
+
+The current public detector baseline remains a general pretrained model with low aerial-person recall on VisDrone. This slice does not claim to solve that model-performance problem by itself. It builds the reporting gate that prevents the project from claiming a fine-tuned detector is better until the evidence is comparable, reproducible, and threshold-safe.
+
+## Design
+
+Add a small report builder around the existing `compare_visdrone_runs.py` gate. It consumes a baseline sweep JSON, a candidate sweep JSON, and optional training metadata, then emits a machine-readable fine-tune report. The report states whether an improvement claim is allowed, which thresholds were compared, which validation manifest checksums were used, and why the candidate failed if it did not pass.
+
+The report deliberately reuses the existing comparison criteria: same validation manifest, matching fixed thresholds, minimum recall delta, minimum precision ratio, and average-precision improvement. This avoids building a second source of truth for detector improvement.
+
+## Scope
+
+This slice adds evidence discipline, not trained weights. Training still requires external aerial-person data and compute. The script should make failed candidates obvious and should exit non-zero by default when the gate fails, so it can be used in CI or release scripts later.
+
+## Validation
+
+Tests cover a passing candidate, a failed precision gate, and CLI behavior that writes a report while returning non-zero for a failed candidate. Documentation explains how to use the report after running the baseline and fine-tuned detector sweeps on the same pinned manifest.

--- a/scripts/report_visdrone_finetune.py
+++ b/scripts/report_visdrone_finetune.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from compare_visdrone_runs import compare_runs, load_json, write_json  # noqa: E402
+
+REPORT_TYPE = "sar-intel-visdrone-finetune-report"
+REPORT_VERSION = 1
+
+
+def _thresholds_compared(comparison: dict[str, Any]) -> list[str]:
+    return sorted(comparison.get("thresholds", {}).keys())
+
+
+def _manifest_checksum(run: dict[str, Any]) -> str | None:
+    manifest = run.get("validation_manifest") or {}
+    checksum = manifest.get("checksum")
+    return str(checksum) if checksum else None
+
+
+def _shared_manifest_checksum(baseline: dict[str, Any], candidate: dict[str, Any]) -> str | None:
+    baseline_checksum = _manifest_checksum(baseline)
+    candidate_checksum = _manifest_checksum(candidate)
+    if baseline_checksum and baseline_checksum == candidate_checksum:
+        return baseline_checksum
+    return None
+
+
+def _normalize_training_metadata(training_metadata: dict[str, Any] | None) -> dict[str, Any]:
+    if not training_metadata:
+        return {
+            "provided": False,
+            "note": "No training metadata supplied. Attach model, dataset, and run metadata before publishing fine-tuned metrics.",
+        }
+    normalized = {str(key): value for key, value in training_metadata.items()}
+    normalized["provided"] = True
+    return normalized
+
+
+def _claim_language(passed: bool) -> str:
+    if passed:
+        return (
+            "Candidate detector is eligible to be described as improved on this VisDrone aerial-person gate: "
+            "it was compared on the same pinned validation manifest, at matching fixed confidence thresholds, "
+            "without an unacceptable precision collapse, and with improved average precision."
+        )
+    return (
+        "Do not describe this detector as improved. The candidate has not passed the same-manifest, "
+        "fixed-threshold recall, precision-ratio, and average-precision gates required for an aerial-person recall claim."
+    )
+
+
+def build_finetune_report(
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    *,
+    training_metadata: dict[str, Any] | None = None,
+    recall_delta: float = 0.05,
+    min_precision_ratio: float = 0.90,
+    ap_delta: float = 0.03,
+) -> dict[str, Any]:
+    comparison = compare_runs(
+        baseline,
+        candidate,
+        recall_delta=recall_delta,
+        min_precision_ratio=min_precision_ratio,
+        ap_delta=ap_delta,
+    )
+    passed = bool(comparison["passed"])
+    thresholds = _thresholds_compared(comparison)
+    return {
+        "type": REPORT_TYPE,
+        "version": REPORT_VERSION,
+        "verdict": "candidate_improved" if passed else "candidate_not_proven",
+        "claim": {
+            "allowed": passed,
+            "language": _claim_language(passed),
+        },
+        "gates": {
+            "recall_delta": recall_delta,
+            "min_precision_ratio": min_precision_ratio,
+            "ap_delta": ap_delta,
+        },
+        "validation": {
+            "manifest_checksum": _shared_manifest_checksum(baseline, candidate),
+            "baseline_manifest_checksum": _manifest_checksum(baseline),
+            "candidate_manifest_checksum": _manifest_checksum(candidate),
+            "thresholds_compared": thresholds,
+        },
+        "training": _normalize_training_metadata(training_metadata),
+        "comparison": comparison,
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build a publishable VisDrone fine-tune report from baseline and candidate sweep outputs."
+    )
+    parser.add_argument("--baseline", required=True, help="Baseline VisDrone sweep JSON.")
+    parser.add_argument("--candidate", required=True, help="Candidate/fine-tuned VisDrone sweep JSON.")
+    parser.add_argument("--training-metadata", help="Optional JSON file describing the training run.")
+    parser.add_argument("--output", default="output/visdrone_finetune_report.json")
+    parser.add_argument("--recall-delta", type=float, default=0.05)
+    parser.add_argument("--min-precision-ratio", type=float, default=0.90)
+    parser.add_argument("--ap-delta", type=float, default=0.03)
+    parser.add_argument(
+        "--always-zero",
+        action="store_true",
+        help="Write the report but exit 0 even when the gate fails. Useful for exploratory local runs.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    training_metadata = load_json(args.training_metadata) if args.training_metadata else None
+    report = build_finetune_report(
+        load_json(args.baseline),
+        load_json(args.candidate),
+        training_metadata=training_metadata,
+        recall_delta=args.recall_delta,
+        min_precision_ratio=args.min_precision_ratio,
+        ap_delta=args.ap_delta,
+    )
+    output_path = write_json(report, args.output)
+    print(f"Saved VisDrone fine-tune report to {output_path}")
+    if report["claim"]["allowed"]:
+        print("Fine-tune report: PASS")
+        return 0
+    print("Fine-tune report: FAIL")
+    for reason in report["comparison"].get("reasons", []):
+        print(f"- {reason}")
+    return 0 if args.always_zero else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_report_visdrone_finetune.py
+++ b/tests/test_report_visdrone_finetune.py
@@ -1,0 +1,130 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "report_visdrone_finetune.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("report_visdrone_finetune", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(threshold_rows, checksum="fixed-manifest", ap=0.20):
+    return {
+        "mode": "sweep",
+        "average_precision": ap,
+        "validation_manifest": {"checksum": checksum},
+        "results": threshold_rows,
+    }
+
+
+def _row(threshold, precision, recall):
+    return {
+        "confidence_threshold": threshold,
+        "precision": precision,
+        "recall": recall,
+        "f1": 0.1,
+        "true_positives": 10,
+        "false_positives": 2,
+        "false_negatives": 90,
+    }
+
+
+def test_report_allows_improvement_claim_only_when_gate_passes():
+    module = _load_module()
+    baseline = _run([
+        _row(0.10, precision=0.60, recall=0.10),
+        _row(0.25, precision=0.80, recall=0.057),
+    ], ap=0.20)
+    candidate = _run([
+        _row(0.10, precision=0.58, recall=0.22),
+        _row(0.25, precision=0.76, recall=0.16),
+    ], ap=0.28)
+
+    report = module.build_finetune_report(
+        baseline,
+        candidate,
+        training_metadata={"model": "runs/visdrone_person/yolo26n/weights/best.pt", "dataset": "visdrone_person"},
+        recall_delta=0.05,
+        min_precision_ratio=0.90,
+        ap_delta=0.03,
+    )
+
+    assert report["type"] == "sar-intel-visdrone-finetune-report"
+    assert report["verdict"] == "candidate_improved"
+    assert report["claim"]["allowed"] is True
+    assert "same pinned validation manifest" in report["claim"]["language"]
+    assert report["validation"]["manifest_checksum"] == "fixed-manifest"
+    assert report["validation"]["thresholds_compared"] == ["0.10", "0.25"]
+    assert report["training"]["dataset"] == "visdrone_person"
+
+
+def test_report_blocks_improvement_claim_when_recall_or_precision_gate_fails():
+    module = _load_module()
+    baseline = _run([_row(0.25, precision=0.80, recall=0.057)], ap=0.20)
+    candidate = _run([_row(0.25, precision=0.30, recall=0.18)], ap=0.30)
+
+    report = module.build_finetune_report(
+        baseline,
+        candidate,
+        recall_delta=0.05,
+        min_precision_ratio=0.90,
+        ap_delta=0.03,
+    )
+
+    assert report["verdict"] == "candidate_not_proven"
+    assert report["claim"]["allowed"] is False
+    assert "precision collapsed at threshold 0.25" in report["comparison"]["reasons"]
+    assert "Do not describe this detector as improved" in report["claim"]["language"]
+
+
+def test_report_marks_shared_manifest_checksum_none_when_manifests_differ():
+    module = _load_module()
+    baseline = _run([_row(0.25, precision=0.80, recall=0.10)], checksum="baseline", ap=0.30)
+    candidate = _run([_row(0.25, precision=0.80, recall=0.20)], checksum="candidate", ap=0.40)
+
+    report = module.build_finetune_report(baseline, candidate)
+
+    assert report["claim"]["allowed"] is False
+    assert report["validation"]["manifest_checksum"] is None
+    assert report["validation"]["baseline_manifest_checksum"] == "baseline"
+    assert report["validation"]["candidate_manifest_checksum"] == "candidate"
+    assert "validation manifest checksum mismatch" in report["comparison"]["reasons"]
+
+def test_cli_writes_report_and_returns_nonzero_for_failed_gate(tmp_path):
+    baseline_path = tmp_path / "baseline.json"
+    candidate_path = tmp_path / "candidate.json"
+    output_path = tmp_path / "report.json"
+    baseline_path.write_text(json.dumps(_run([_row(0.25, precision=0.80, recall=0.10)], ap=0.30)), encoding="utf-8")
+    candidate_path.write_text(json.dumps(_run([_row(0.25, precision=0.20, recall=0.30)], ap=0.40)), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/report_visdrone_finetune.py",
+            "--baseline",
+            str(baseline_path),
+            "--candidate",
+            str(candidate_path),
+            "--output",
+            str(output_path),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert output_path.exists()
+    report = json.loads(output_path.read_text(encoding="utf-8"))
+    assert report["claim"]["allowed"] is False
+    assert "Fine-tune report: FAIL" in result.stdout


### PR DESCRIPTION
## Summary
- add `scripts/report_visdrone_finetune.py` to build a publish/no-publish report for aerial-person fine-tune claims
- reuse the existing same-manifest, fixed-threshold, precision-ratio, and AP comparison gate
- make failed gates exit non-zero by default so the report can protect releases/claims
- document that the public detector remains the pre-fine-tune baseline until `claim.allowed` is true

## Verification
- red test observed first: `python -m pytest tests\test_report_visdrone_finetune.py -q` failed because the report script did not exist
- `python -m pytest tests\test_report_visdrone_finetune.py tests\test_compare_visdrone_runs.py -q` -> 8 passed
- `python -m compileall scripts\report_visdrone_finetune.py`
- `python -m pytest` -> 81 passed
- `python scripts\verify_release.py`

## Notes
This does not claim the 5.7% recall baseline is fixed. It adds the gate that a future fine-tuned model must pass before we can honestly say recall improved.