### PR TITLE
[codex] Add aerial dataset intake audit

### DIFF
--- a/docs/AERIAL_DATASET_INTAKE.md
+++ b/docs/AERIAL_DATASET_INTAKE.md
@@ -1,0 +1,26 @@
+# Aerial Dataset Intake
+
+The detector is still the pre-fine-tune baseline until a candidate model passes the fine-tune report gate. This file tracks the external aerial-person datasets that can close that gap.
+
+## Audit external datasets
+
+Datasets are not committed to this repository. Keep raw data local, review license/access terms, then audit the local layout:
+
+```bash
+python scripts/audit_aerial_datasets.py \
+  --dataset-root heridal=/data/HERIDAL \
+  --dataset-root seadronessee=/data/SeaDronesSee \
+  --dataset-root visdrone-person=/data/visdrone_person \
+  --output output/aerial_dataset_audit.json
+```
+
+A dataset marked `ready_for_converter` has the expected top-level paths for a converter. That does not mean it is validated, licensed for redistribution, or sufficient for a recall claim.
+
+## Priority
+
+1. HERIDAL: closest wilderness/mountain SAR fit.
+2. SeaDronesSee: maritime SAR-relevant imagery.
+3. VisDrone person-only: existing general aerial baseline and fixed validation path.
+4. Okutama-Action and AU-AIR: supplemental domain-transfer sources.
+
+The next recall milestone is not visual polish. It is: audit local dataset roots, write converters for ready datasets, train a candidate, evaluate on the pinned manifest, then publish only if `scripts/report_visdrone_finetune.py` returns `claim.allowed: true`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,6 +19,7 @@ This roadmap is bold about direction and conservative about claims. Every new in
 - SHA256-pinned VisDrone validation manifests
 - Fixed-threshold AP / PR-curve reporting for detector comparisons
 - Fine-tune report gate for publish/no-publish aerial recall claims
+- Aerial dataset intake audit for HERIDAL, SeaDronesSee, VisDrone-person, Okutama-Action, and AU-AIR
 
 ## Near-term
 

--- a/docs/superpowers/specs/2026-07-02-aerial-dataset-intake-design.md
+++ b/docs/superpowers/specs/2026-07-02-aerial-dataset-intake-design.md
@@ -1,0 +1,13 @@
+# Aerial Dataset Intake Design
+
+## Purpose
+
+Move the recall fix from discussion toward execution by tracking external aerial-person datasets needed for fine-tuning. The script does not download or redistribute data. It audits local dataset roots and records whether each source is ready for converter work.
+
+## Design
+
+`scripts/audit_aerial_datasets.py` owns a small registry of SAR-relevant aerial-person datasets. Each entry states the dataset id, SAR relevance, required local paths, and claim status. The CLI accepts `--dataset-root id=path` values and writes `output/aerial_dataset_audit.json`.
+
+## Claim Discipline
+
+A dataset being present does not fix recall. It only unlocks converter and training work. The project should continue to say the public detector is the pre-fine-tune baseline until a trained candidate passes the fine-tune report gate.

--- a/scripts/audit_aerial_datasets.py
+++ b/scripts/audit_aerial_datasets.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+DATASET_REGISTRY: list[dict[str, Any]] = [
+    {
+        "id": "heridal",
+        "name": "HERIDAL",
+        "task": "aerial-person-detection",
+        "sar_relevance": "mountain/wilderness SAR imagery",
+        "required_paths": ["images", "annotations"],
+        "claim_status": "candidate-training-source",
+        "notes": "Use only after local license/access review; not committed to this repo.",
+    },
+    {
+        "id": "seadronessee",
+        "name": "SeaDronesSee",
+        "task": "aerial-person-detection",
+        "sar_relevance": "maritime drone SAR imagery",
+        "required_paths": ["images", "annotations"],
+        "claim_status": "candidate-training-source",
+        "notes": "Dataset layouts vary by release; audit before writing a converter.",
+    },
+    {
+        "id": "visdrone-person",
+        "name": "VisDrone person-only",
+        "task": "aerial-person-detection",
+        "sar_relevance": "general aerial pedestrian/people detection baseline",
+        "required_paths": ["images/train", "images/val", "labels/train", "labels/val", "visdrone_person.yaml"],
+        "claim_status": "candidate-training-source",
+        "notes": "Prepared by scripts/prepare_visdrone_person_yolo.py.",
+    },
+    {
+        "id": "okutama-action",
+        "name": "Okutama-Action",
+        "task": "aerial-person-detection",
+        "sar_relevance": "aerial human imagery with action-oriented scenes",
+        "required_paths": ["images", "annotations"],
+        "claim_status": "candidate-training-source",
+        "notes": "Treat as supplementary domain-transfer data, not a SAR benchmark.",
+    },
+    {
+        "id": "au-air",
+        "name": "AU-AIR",
+        "task": "aerial-person-detection",
+        "sar_relevance": "low-altitude UAV traffic/person imagery",
+        "required_paths": ["images", "annotations"],
+        "claim_status": "candidate-training-source",
+        "notes": "Useful for domain diversity; not SAR-specific.",
+    },
+]
+
+
+def _registry_by_id() -> dict[str, dict[str, Any]]:
+    return {dataset["id"]: dataset for dataset in DATASET_REGISTRY}
+
+
+def parse_dataset_root(value: str) -> tuple[str, Path]:
+    if "=" not in value:
+        raise argparse.ArgumentTypeError("dataset roots must use id=path format")
+    dataset_id, path = value.split("=", 1)
+    dataset_id = dataset_id.strip()
+    if dataset_id not in _registry_by_id():
+        raise argparse.ArgumentTypeError(f"unknown dataset id: {dataset_id}")
+    return dataset_id, Path(path)
+
+
+def audit_dataset(dataset: dict[str, Any], root: Path | None) -> dict[str, Any]:
+    result = {
+        "id": dataset["id"],
+        "name": dataset["name"],
+        "task": dataset["task"],
+        "claim_status": dataset["claim_status"],
+        "root": str(root) if root is not None else None,
+        "required_paths": dataset["required_paths"],
+        "missing_paths": [],
+        "status": "not_configured",
+        "notes": dataset["notes"],
+    }
+    if root is None:
+        return result
+    if not root.exists():
+        result["status"] = "missing_root"
+        return result
+    missing = [relative for relative in dataset["required_paths"] if not (root / relative).exists()]
+    result["missing_paths"] = missing
+    result["status"] = "ready_for_converter" if not missing else "missing_required_paths"
+    return result
+
+
+def build_dataset_audit(dataset_roots: Mapping[str, str | Path]) -> dict[str, Any]:
+    normalized_roots = {dataset_id: Path(root) for dataset_id, root in dataset_roots.items()}
+    datasets = [audit_dataset(dataset, normalized_roots.get(dataset["id"])) for dataset in DATASET_REGISTRY]
+    summary: dict[str, int] = {}
+    for item in datasets:
+        summary[item["status"]] = summary.get(item["status"], 0) + 1
+    return {
+        "type": "sar-intel-aerial-dataset-audit",
+        "version": 1,
+        "purpose": "Track external aerial-person datasets needed to move beyond the pre-fine-tune baseline.",
+        "summary": summary,
+        "datasets": datasets,
+    }
+
+
+def write_json(data: dict[str, Any], path: str | Path) -> Path:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return output
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Audit external aerial-person datasets for SAR-INTEL fine-tuning readiness.")
+    parser.add_argument("--dataset-root", action="append", default=[], type=parse_dataset_root, help="Dataset root in id=path form.")
+    parser.add_argument("--output", default="output/aerial_dataset_audit.json")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = build_dataset_audit(dict(args.dataset_root))
+    output = write_json(report, args.output)
+    print(f"Aerial dataset audit written to {output}")
+    print(f"Ready for converter: {report['summary'].get('ready_for_converter', 0)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_aerial_dataset_audit.py
+++ b/tests/test_aerial_dataset_audit.py
@@ -1,0 +1,78 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "audit_aerial_datasets.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("audit_aerial_datasets", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_registry_prioritizes_sar_relevant_aerial_person_datasets():
+    module = _load_module()
+
+    ids = [dataset["id"] for dataset in module.DATASET_REGISTRY]
+
+    assert ids[:3] == ["heridal", "seadronessee", "visdrone-person"]
+    assert all(dataset["task"] == "aerial-person-detection" for dataset in module.DATASET_REGISTRY)
+    assert all(dataset["claim_status"] == "candidate-training-source" for dataset in module.DATASET_REGISTRY)
+
+
+def test_audit_reports_ready_missing_and_blocked_dataset_roots(tmp_path):
+    module = _load_module()
+    heridal = tmp_path / "HERIDAL"
+    (heridal / "images").mkdir(parents=True)
+    (heridal / "annotations").mkdir()
+    seadrones = tmp_path / "SeaDronesSee"
+    seadrones.mkdir()
+
+    report = module.build_dataset_audit(
+        {
+            "heridal": heridal,
+            "seadronessee": seadrones,
+            "visdrone-person": tmp_path / "missing-visdrone",
+        }
+    )
+
+    by_id = {item["id"]: item for item in report["datasets"]}
+    assert by_id["heridal"]["status"] == "ready_for_converter"
+    assert by_id["seadronessee"]["status"] == "missing_required_paths"
+    assert by_id["visdrone-person"]["status"] == "missing_root"
+    assert report["summary"]["ready_for_converter"] == 1
+    assert report["summary"]["missing_required_paths"] == 1
+    assert report["summary"]["missing_root"] == 1
+
+
+def test_cli_writes_audit_report(tmp_path):
+    root = tmp_path / "HERIDAL"
+    (root / "images").mkdir(parents=True)
+    (root / "annotations").mkdir()
+    output = tmp_path / "audit.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/audit_aerial_datasets.py",
+            "--dataset-root",
+            f"heridal={root}",
+            "--output",
+            str(output),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["summary"]["ready_for_converter"] == 1
+    assert "Aerial dataset audit" in result.stdout


### PR DESCRIPTION
## Summary
- add an aerial-person dataset registry/intake audit for HERIDAL, SeaDronesSee, VisDrone-person, Okutama-Action, and AU-AIR
- add `scripts/audit_aerial_datasets.py` to report local dataset readiness without committing or redistributing data
- document that dataset readiness does not fix recall until converters, training, evaluation, and the fine-tune report gate pass

## Verification
- red test observed first: script missing
- `python -m pytest tests\test_aerial_dataset_audit.py -q` -> 3 passed
- `python -m pytest` -> 84 passed
- `python scripts\verify_release.py`