### PR TITLE
[codex] Add HERIDAL person YOLO converter

### DIFF
--- a/docs/HERIDAL_CONVERSION.md
+++ b/docs/HERIDAL_CONVERSION.md
@@ -1,0 +1,28 @@
+# HERIDAL Person YOLO Conversion
+
+This is the first converter on the aerial recall track. It does not fix recall by itself; it prepares local HERIDAL-style aerial-person data for training experiments.
+
+Supported local annotation layouts:
+
+- `annotations/*.xml` in Pascal VOC bounding-box form
+- `annotations/annotations.csv` with `filename,xmin,ymin,xmax,ymax,class`
+
+Raw datasets are not committed to this repo.
+
+```bash
+python scripts/prepare_heridal_person_yolo.py \
+  --heridal-root /data/HERIDAL \
+  --output-root /data/heridal_person_yolo \
+  --copy-mode copy
+```
+
+Output:
+
+```text
+heridal_person_yolo/
+  images/train/
+  labels/train/
+  heridal_person.yaml
+```
+
+Train only after checking dataset license/access terms. Publish no recall-improvement claim until the trained candidate passes `scripts/report_visdrone_finetune.py` on a pinned validation manifest.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,6 +20,7 @@ This roadmap is bold about direction and conservative about claims. Every new in
 - Fixed-threshold AP / PR-curve reporting for detector comparisons
 - Fine-tune report gate for publish/no-publish aerial recall claims
 - Aerial dataset intake audit for HERIDAL, SeaDronesSee, VisDrone-person, Okutama-Action, and AU-AIR
+- HERIDAL-style person-only YOLO conversion for the first external SAR-relevant training source
 
 ## Near-term
 

--- a/scripts/prepare_heridal_person_yolo.py
+++ b/scripts/prepare_heridal_person_yolo.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import shutil
+import sys
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from pathlib import Path
+from typing import Sequence
+
+from PIL import Image
+
+PERSON_LABELS = {"person", "human", "pedestrian", "people"}
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png"}
+
+
+def yolo_line(xmin: float, ymin: float, xmax: float, ymax: float, image_width: int, image_height: int) -> str:
+    xmin = max(0.0, min(float(image_width), xmin))
+    xmax = max(0.0, min(float(image_width), xmax))
+    ymin = max(0.0, min(float(image_height), ymin))
+    ymax = max(0.0, min(float(image_height), ymax))
+    if xmax <= xmin or ymax <= ymin:
+        raise ValueError("invalid bounding box with non-positive area")
+    cx = ((xmin + xmax) / 2.0) / image_width
+    cy = ((ymin + ymax) / 2.0) / image_height
+    width = (xmax - xmin) / image_width
+    height = (ymax - ymin) / image_height
+    return f"0 {cx:.6f} {cy:.6f} {width:.6f} {height:.6f}"
+
+
+def image_size(path: Path) -> tuple[int, int]:
+    with Image.open(path) as frame:
+        return frame.size
+
+
+def image_paths(images_dir: Path) -> list[Path]:
+    return sorted(path for path in images_dir.iterdir() if path.suffix.lower() in IMAGE_EXTENSIONS)
+
+
+def parse_xml_annotations(annotation_path: Path) -> list[tuple[float, float, float, float]]:
+    root = ET.parse(annotation_path).getroot()
+    boxes = []
+    for obj in root.findall(".//object"):
+        name = (obj.findtext("name") or "person").strip().lower()
+        if name and name not in PERSON_LABELS:
+            continue
+        box = obj.find("bndbox")
+        if box is None:
+            continue
+        boxes.append((
+            float(box.findtext("xmin", "0")),
+            float(box.findtext("ymin", "0")),
+            float(box.findtext("xmax", "0")),
+            float(box.findtext("ymax", "0")),
+        ))
+    return boxes
+
+
+def parse_csv_annotations(csv_path: Path) -> dict[str, list[tuple[float, float, float, float]]]:
+    grouped: dict[str, list[tuple[float, float, float, float]]] = defaultdict(list)
+    with csv_path.open(newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            label = (row.get("class") or row.get("label") or "person").strip().lower()
+            if label not in PERSON_LABELS:
+                continue
+            filename = row.get("filename") or row.get("image") or row.get("file")
+            if not filename:
+                raise ValueError("CSV annotation row is missing filename/image/file")
+            grouped[Path(filename).name].append((
+                float(row["xmin"]),
+                float(row["ymin"]),
+                float(row["xmax"]),
+                float(row["ymax"]),
+            ))
+    return dict(grouped)
+
+
+def materialize_image(source: Path, destination: Path, copy_mode: str) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if copy_mode == "copy":
+        shutil.copy2(source, destination)
+    elif copy_mode == "symlink":
+        if destination.exists():
+            destination.unlink()
+        destination.symlink_to(source.resolve())
+    else:
+        raise ValueError("copy_mode must be copy or symlink")
+
+
+def write_dataset_yaml(output_root: Path) -> None:
+    (output_root / "heridal_person.yaml").write_text(
+        "train: images/train\nval: images/train\nnc: 1\nnames: ['person']\n",
+        encoding="utf-8",
+    )
+
+
+def load_annotation_map(annotations_dir: Path) -> tuple[str, dict[str, list[tuple[float, float, float, float]]]]:
+    csv_path = annotations_dir / "annotations.csv"
+    if csv_path.exists():
+        return "csv", parse_csv_annotations(csv_path)
+    xml_files = sorted(annotations_dir.glob("*.xml"))
+    if xml_files:
+        return "voc_xml", {path.with_suffix(".jpg").name: parse_xml_annotations(path) for path in xml_files}
+    raise FileNotFoundError("Expected annotations as annotations/*.xml or annotations/annotations.csv")
+
+
+def convert_dataset(heridal_root: str | Path, output_root: str | Path, *, copy_mode: str = "copy") -> dict[str, int | str]:
+    root = Path(heridal_root)
+    output = Path(output_root)
+    images_dir = root / "images"
+    annotations_dir = root / "annotations"
+    if not images_dir.is_dir():
+        raise FileNotFoundError(f"Missing images directory: {images_dir}")
+    if not annotations_dir.is_dir():
+        raise FileNotFoundError(f"Expected annotations directory: {annotations_dir}")
+
+    annotation_format, annotations = load_annotation_map(annotations_dir)
+    output_images = output / "images" / "train"
+    output_labels = output / "labels" / "train"
+    output_labels.mkdir(parents=True, exist_ok=True)
+
+    image_count = 0
+    box_count = 0
+    for image_path in image_paths(images_dir):
+        width, height = image_size(image_path)
+        boxes = annotations.get(image_path.name) or annotations.get(image_path.with_suffix(".jpg").name) or []
+        lines = [yolo_line(*box, image_width=width, image_height=height) for box in boxes]
+        materialize_image(image_path, output_images / image_path.name, copy_mode)
+        (output_labels / f"{image_path.stem}.txt").write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+        image_count += 1
+        box_count += len(lines)
+
+    write_dataset_yaml(output)
+    return {"images": image_count, "boxes": box_count, "annotation_format": annotation_format}
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Convert a local HERIDAL-style aerial-person dataset to person-only YOLO format.")
+    parser.add_argument("--heridal-root", required=True)
+    parser.add_argument("--output-root", required=True)
+    parser.add_argument("--copy-mode", choices=("copy", "symlink"), default="copy")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        result = convert_dataset(args.heridal_root, args.output_root, copy_mode=args.copy_mode)
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(f"HERIDAL conversion complete: {result['images']} images, {result['boxes']} boxes, format={result['annotation_format']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_heridal_person_conversion.py
+++ b/tests/test_heridal_person_conversion.py
@@ -1,0 +1,75 @@
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "prepare_heridal_person_yolo.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("prepare_heridal_person_yolo", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_image(path: Path, size=(100, 50)):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", size, color=(20, 40, 60)).save(path)
+
+
+def test_converts_voc_xml_annotations_to_person_yolo(tmp_path):
+    module = _load_module()
+    root = tmp_path / "HERIDAL"
+    _write_image(root / "images" / "frame001.jpg")
+    (root / "annotations").mkdir()
+    (root / "annotations" / "frame001.xml").write_text(
+        """<annotation><object><name>person</name><bndbox><xmin>10</xmin><ymin>5</ymin><xmax>30</xmax><ymax>25</ymax></bndbox></object></annotation>""",
+        encoding="utf-8",
+    )
+
+    result = module.convert_dataset(root, tmp_path / "out", copy_mode="copy")
+
+    label = (tmp_path / "out" / "labels" / "train" / "frame001.txt").read_text(encoding="utf-8").strip()
+    assert label == "0 0.200000 0.300000 0.200000 0.400000"
+    assert result["images"] == 1
+    assert result["boxes"] == 1
+    assert (tmp_path / "out" / "images" / "train" / "frame001.jpg").exists()
+    assert "train: images/train" in (tmp_path / "out" / "heridal_person.yaml").read_text(encoding="utf-8")
+
+
+def test_converts_csv_annotations_to_person_yolo(tmp_path):
+    module = _load_module()
+    root = tmp_path / "HERIDAL"
+    _write_image(root / "images" / "frame002.jpg", size=(200, 100))
+    (root / "annotations").mkdir()
+    (root / "annotations" / "annotations.csv").write_text(
+        "filename,xmin,ymin,xmax,ymax,class\nframe002.jpg,50,20,90,60,person\n",
+        encoding="utf-8",
+    )
+
+    module.convert_dataset(root, tmp_path / "out", copy_mode="copy")
+
+    label = (tmp_path / "out" / "labels" / "train" / "frame002.txt").read_text(encoding="utf-8").strip()
+    assert label == "0 0.350000 0.400000 0.200000 0.400000"
+
+
+def test_cli_requires_known_layout(tmp_path):
+    root = tmp_path / "bad"
+    (root / "images").mkdir(parents=True)
+    output = tmp_path / "out"
+
+    result = subprocess.run(
+        [sys.executable, "scripts/prepare_heridal_person_yolo.py", "--heridal-root", str(root), "--output-root", str(output)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Expected annotations" in result.stderr


### PR DESCRIPTION
## Summary
- add `scripts/prepare_heridal_person_yolo.py`
- support Pascal VOC XML and `annotations.csv` local layouts
- output person-only YOLO training layout plus `heridal_person.yaml`
- document that this prepares data but does not itself fix recall

## Verification
- red test observed first: converter script missing
- `python -m pytest tests\test_heridal_person_conversion.py tests\test_aerial_dataset_audit.py -q` -> 6 passed
- `python -m pytest` -> 87 passed
- `python scripts\verify_release.py`