### PR TITLE
[codex] Add combined person YOLO dataset builder

### DIFF
--- a/docs/COMBINED_YOLO_DATASET.md
+++ b/docs/COMBINED_YOLO_DATASET.md
@@ -1,0 +1,24 @@
+# Combined Person YOLO Dataset
+
+Use this after converting individual sources such as VisDrone-person and HERIDAL-person. It creates one training dataset with source-prefixed filenames and a provenance manifest.
+
+```bash
+python scripts/combine_person_yolo_datasets.py \
+  --source heridal=/data/heridal_person_yolo \
+  --source visdrone=/data/visdrone_person \
+  --output-root /data/sar_intel_person_yolo
+```
+
+Output:
+
+```text
+sar_intel_person_yolo/
+  images/train/
+  images/val/
+  labels/train/
+  labels/val/
+  combined_person.yaml
+  combined_manifest.json
+```
+
+The manifest records source ids, counts, output files, and SHA256 hashes of source images/labels. This is the dataset provenance anchor for future training runs. A combined dataset still does not prove recall improved; only the fine-tune report gate can allow that claim after evaluation.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,6 +21,7 @@ This roadmap is bold about direction and conservative about claims. Every new in
 - Fine-tune report gate for publish/no-publish aerial recall claims
 - Aerial dataset intake audit for HERIDAL, SeaDronesSee, VisDrone-person, Okutama-Action, and AU-AIR
 - HERIDAL-style person-only YOLO conversion for the first external SAR-relevant training source
+- Combined person-YOLO dataset builder with source-prefixed files and provenance manifest
 
 ## Near-term
 

--- a/scripts/combine_person_yolo_datasets.py
+++ b/scripts/combine_person_yolo_datasets.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png"}
+SPLITS = ("train", "val")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parse_source(value: str) -> tuple[str, Path]:
+    if "=" not in value:
+        raise argparse.ArgumentTypeError("sources must use id=path format")
+    source_id, path = value.split("=", 1)
+    source_id = source_id.strip()
+    if not source_id or any(char in source_id for char in "\\/ :"):
+        raise argparse.ArgumentTypeError("source id must be a simple filename-safe token")
+    return source_id, Path(path)
+
+
+def image_files(root: Path, split: str) -> list[Path]:
+    directory = root / "images" / split
+    if not directory.exists():
+        return []
+    return sorted(path for path in directory.iterdir() if path.suffix.lower() in IMAGE_EXTENSIONS)
+
+
+def validate_source(root: Path, split: str) -> None:
+    images_dir = root / "images" / split
+    labels_dir = root / "labels" / split
+    if images_dir.exists() and not labels_dir.exists():
+        raise FileNotFoundError(f"Missing labels/{split} for source: {root}")
+
+
+def materialize(source: Path, destination: Path, copy_mode: str) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if copy_mode == "copy":
+        shutil.copy2(source, destination)
+    elif copy_mode == "symlink":
+        if destination.exists():
+            destination.unlink()
+        destination.symlink_to(source.resolve())
+    else:
+        raise ValueError("copy_mode must be copy or symlink")
+
+
+def write_yaml(output_root: Path) -> None:
+    (output_root / "combined_person.yaml").write_text(
+        "train: images/train\nval: images/val\nnc: 1\nnames: ['person']\n",
+        encoding="utf-8",
+    )
+
+
+def combine_datasets(
+    sources: Sequence[tuple[str, str | Path]],
+    output_root: str | Path,
+    *,
+    copy_mode: str = "copy",
+) -> dict[str, Any]:
+    output = Path(output_root)
+    source_reports: list[dict[str, Any]] = []
+    total_images = 0
+    total_labels = 0
+
+    for source_id, source_root_raw in sources:
+        source_root = Path(source_root_raw)
+        if not source_root.exists():
+            raise FileNotFoundError(f"Missing source root: {source_root}")
+        source_report: dict[str, Any] = {"id": source_id, "root": str(source_root), "splits": {}}
+        for split in SPLITS:
+            validate_source(source_root, split)
+            split_images = image_files(source_root, split)
+            split_report = {"images": 0, "labels": 0, "files": []}
+            for image_path in split_images:
+                label_path = source_root / "labels" / split / f"{image_path.stem}.txt"
+                if not label_path.exists():
+                    raise FileNotFoundError(f"Missing label for {image_path.name}: {label_path}")
+                prefix = f"{source_id}__{image_path.stem}"
+                output_image = output / "images" / split / f"{prefix}{image_path.suffix.lower()}"
+                output_label = output / "labels" / split / f"{prefix}.txt"
+                materialize(image_path, output_image, copy_mode)
+                materialize(label_path, output_label, copy_mode)
+                split_report["images"] += 1
+                split_report["labels"] += 1
+                split_report["files"].append({
+                    "image": str(output_image.relative_to(output)),
+                    "label": str(output_label.relative_to(output)),
+                    "source_image_sha256": sha256_file(image_path),
+                    "source_label_sha256": sha256_file(label_path),
+                })
+            source_report["splits"][split] = split_report
+            total_images += split_report["images"]
+            total_labels += split_report["labels"]
+        source_reports.append(source_report)
+
+    write_yaml(output)
+    manifest = {
+        "type": "sar-intel-combined-person-yolo-dataset",
+        "version": 1,
+        "copy_mode": copy_mode,
+        "summary": {"sources": len(source_reports), "images": total_images, "labels": total_labels},
+        "sources": source_reports,
+    }
+    (output / "combined_manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return manifest
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Combine prepared person-only YOLO datasets with source-prefixed filenames.")
+    parser.add_argument("--source", action="append", required=True, type=parse_source, help="Prepared YOLO source as id=path")
+    parser.add_argument("--output-root", required=True)
+    parser.add_argument("--copy-mode", choices=("copy", "symlink"), default="copy")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        manifest = combine_datasets(args.source, args.output_root, copy_mode=args.copy_mode)
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(f"Combined YOLO dataset: {manifest['summary']['images']} images from {manifest['summary']['sources']} sources")
+    print(f"Manifest: {Path(args.output_root) / 'combined_manifest.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_combine_person_yolo_datasets.py
+++ b/tests/test_combine_person_yolo_datasets.py
@@ -1,0 +1,93 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "combine_person_yolo_datasets.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("combine_person_yolo_datasets", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_dataset(root: Path, name: str, split: str = "train") -> None:
+    (root / "images" / split).mkdir(parents=True)
+    (root / "labels" / split).mkdir(parents=True)
+    (root / "images" / split / f"{name}.jpg").write_bytes(b"image-" + name.encode())
+    (root / "labels" / split / f"{name}.txt").write_text("0 0.5 0.5 0.2 0.2\n", encoding="utf-8")
+
+
+def test_combines_sources_with_prefixed_files_and_manifest(tmp_path):
+    module = _load_module()
+    heridal = tmp_path / "heridal"
+    visdrone = tmp_path / "visdrone"
+    _write_dataset(heridal, "frame001", "train")
+    _write_dataset(visdrone, "frame001", "train")
+    _write_dataset(visdrone, "frame002", "val")
+
+    result = module.combine_datasets(
+        [("heridal", heridal), ("visdrone", visdrone)],
+        tmp_path / "combined",
+        copy_mode="copy",
+    )
+
+    combined = tmp_path / "combined"
+    assert (combined / "images" / "train" / "heridal__frame001.jpg").exists()
+    assert (combined / "images" / "train" / "visdrone__frame001.jpg").exists()
+    assert (combined / "labels" / "val" / "visdrone__frame002.txt").exists()
+    assert "train: images/train" in (combined / "combined_person.yaml").read_text(encoding="utf-8")
+    manifest = json.loads((combined / "combined_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["summary"]["images"] == 3
+    assert manifest["summary"]["labels"] == 3
+    assert manifest["sources"][0]["id"] == "heridal"
+    assert manifest["sources"][0]["splits"]["train"]["images"] == 1
+    assert result["summary"]["images"] == 3
+
+
+def test_rejects_source_missing_labels(tmp_path):
+    module = _load_module()
+    source = tmp_path / "bad"
+    (source / "images" / "train").mkdir(parents=True)
+    (source / "images" / "train" / "sample.jpg").write_bytes(b"image")
+
+    try:
+        module.combine_datasets([("bad", source)], tmp_path / "combined")
+    except FileNotFoundError as exc:
+        assert "labels/train" in str(exc)
+    else:
+        raise AssertionError("expected FileNotFoundError")
+
+
+def test_cli_combines_sources(tmp_path):
+    heridal = tmp_path / "heridal"
+    visdrone = tmp_path / "visdrone"
+    _write_dataset(heridal, "a", "train")
+    _write_dataset(visdrone, "b", "train")
+    output = tmp_path / "combined"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/combine_person_yolo_datasets.py",
+            "--source",
+            f"heridal={heridal}",
+            "--source",
+            f"visdrone={visdrone}",
+            "--output-root",
+            str(output),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert (output / "combined_manifest.json").exists()
+    assert "Combined YOLO dataset" in result.stdout


### PR DESCRIPTION
## Summary
- add `scripts/combine_person_yolo_datasets.py`
- combine prepared person-only YOLO sources with source-prefixed filenames
- write `combined_person.yaml` and `combined_manifest.json` with counts and SHA256 provenance
- document how this feeds the training/evaluation recall track

## Verification
- red test observed first: builder script missing
- `python -m pytest tests\test_combine_person_yolo_datasets.py tests\test_heridal_person_conversion.py tests\test_visdrone_person_conversion.py -q` -> 14 passed
- `python -m pytest` -> 90 passed
- `python scripts\verify_release.py`