### PR TITLE
[codex] Add recall experiment runner

### DIFF
--- a/docs/RECALL_EXPERIMENT_RUNNER.md
+++ b/docs/RECALL_EXPERIMENT_RUNNER.md
@@ -1,0 +1,27 @@
+# Recall Experiment Runner
+
+This is the professional glue for the aerial recall track. It assembles dataset provenance, a candidate sweep, and the fine-tune report gate into one experiment directory.
+
+Current mode is precomputed-candidate: train/evaluate elsewhere, then pass the candidate sweep here. This keeps CI GPU-free while preserving the publish/no-publish gate.
+
+```bash
+python scripts/run_recall_experiment.py \
+  --dataset-yaml /data/sar_intel_person_yolo/combined_person.yaml \
+  --dataset-manifest /data/sar_intel_person_yolo/combined_manifest.json \
+  --baseline-sweep output/visdrone_det_sweep.json \
+  --candidate-sweep output/visdrone_det_finetuned_sweep.json \
+  --output-dir output/recall_experiment \
+  --experiment-name heridal-visdrone-yolo26n
+```
+
+Outputs:
+
+```text
+output/recall_experiment/
+  training_metadata.json
+  candidate_sweep.json
+  finetune_report.json
+  recall_experiment_summary.json
+```
+
+A `PASS` means `claim_allowed` is true under the fixed gate thresholds. A `FAIL` is still useful: it preserves the exact dataset and sweep provenance for the failed candidate.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,6 +22,7 @@ This roadmap is bold about direction and conservative about claims. Every new in
 - Aerial dataset intake audit for HERIDAL, SeaDronesSee, VisDrone-person, Okutama-Action, and AU-AIR
 - HERIDAL-style person-only YOLO conversion for the first external SAR-relevant training source
 - Combined person-YOLO dataset builder with source-prefixed files and provenance manifest
+- Recall experiment runner that links dataset provenance, candidate sweep, and fine-tune claim gate
 
 ## Near-term
 

--- a/scripts/run_recall_experiment.py
+++ b/scripts/run_recall_experiment.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from report_visdrone_finetune import build_finetune_report  # noqa: E402
+
+
+def sha256_file(path: Path) -> str:
+    import hashlib
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_json(path: str | Path) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def write_json(data: dict[str, Any], path: str | Path) -> Path:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return output
+
+
+def require_file(path: str | Path, label: str) -> Path:
+    resolved = Path(path)
+    if not resolved.exists():
+        raise FileNotFoundError(f"Missing {label}: {resolved}")
+    return resolved
+
+
+def build_training_metadata(
+    *,
+    dataset_yaml: Path,
+    dataset_manifest: Path,
+    experiment_name: str,
+    mode: str,
+) -> dict[str, Any]:
+    return {
+        "type": "sar-intel-recall-training-metadata",
+        "version": 1,
+        "experiment_name": experiment_name,
+        "mode": mode,
+        "created_at_utc": datetime.now(timezone.utc).isoformat(),
+        "dataset": {
+            "yaml": str(dataset_yaml),
+            "yaml_sha256": sha256_file(dataset_yaml),
+            "manifest": str(dataset_manifest),
+            "manifest_sha256": sha256_file(dataset_manifest),
+            "manifest_payload": load_json(dataset_manifest),
+        },
+        "note": "Precomputed mode records provenance and gates an existing candidate sweep; it does not train a model.",
+    }
+
+
+def run_precomputed_experiment(
+    *,
+    dataset_yaml: str | Path,
+    dataset_manifest: str | Path,
+    baseline_sweep: str | Path,
+    candidate_sweep: str | Path,
+    output_dir: str | Path,
+    experiment_name: str = "recall-experiment",
+    recall_delta: float = 0.05,
+    min_precision_ratio: float = 0.90,
+    ap_delta: float = 0.03,
+) -> dict[str, Any]:
+    dataset_yaml_path = require_file(dataset_yaml, "dataset yaml")
+    dataset_manifest_path = require_file(dataset_manifest, "dataset manifest")
+    baseline_path = require_file(baseline_sweep, "baseline sweep")
+    candidate_path = require_file(candidate_sweep, "candidate sweep")
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+
+    training_metadata = build_training_metadata(
+        dataset_yaml=dataset_yaml_path,
+        dataset_manifest=dataset_manifest_path,
+        experiment_name=experiment_name,
+        mode="precomputed-candidate",
+    )
+    write_json(training_metadata, output / "training_metadata.json")
+    shutil.copy2(candidate_path, output / "candidate_sweep.json")
+
+    report = build_finetune_report(
+        load_json(baseline_path),
+        load_json(candidate_path),
+        training_metadata=training_metadata,
+        recall_delta=recall_delta,
+        min_precision_ratio=min_precision_ratio,
+        ap_delta=ap_delta,
+    )
+    write_json(report, output / "finetune_report.json")
+
+    summary = {
+        "type": "sar-intel-recall-experiment-summary",
+        "version": 1,
+        "experiment_name": experiment_name,
+        "mode": "precomputed-candidate",
+        "claim_allowed": bool(report["claim"]["allowed"]),
+        "verdict": report["verdict"],
+        "dataset": training_metadata["dataset"],
+        "outputs": {
+            "training_metadata": str(output / "training_metadata.json"),
+            "candidate_sweep": str(output / "candidate_sweep.json"),
+            "finetune_report": str(output / "finetune_report.json"),
+        },
+        "comparison_reasons": report["comparison"].get("reasons", []),
+    }
+    write_json(summary, output / "recall_experiment_summary.json")
+    return summary
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run or assemble a SAR-INTEL aerial recall experiment report.")
+    parser.add_argument("--dataset-yaml", required=True)
+    parser.add_argument("--dataset-manifest", required=True)
+    parser.add_argument("--baseline-sweep", required=True)
+    parser.add_argument("--candidate-sweep", required=True, help="Precomputed candidate sweep JSON to gate.")
+    parser.add_argument("--output-dir", default="output/recall_experiment")
+    parser.add_argument("--experiment-name", default="recall-experiment")
+    parser.add_argument("--recall-delta", type=float, default=0.05)
+    parser.add_argument("--min-precision-ratio", type=float, default=0.90)
+    parser.add_argument("--ap-delta", type=float, default=0.03)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        summary = run_precomputed_experiment(
+            dataset_yaml=args.dataset_yaml,
+            dataset_manifest=args.dataset_manifest,
+            baseline_sweep=args.baseline_sweep,
+            candidate_sweep=args.candidate_sweep,
+            output_dir=args.output_dir,
+            experiment_name=args.experiment_name,
+            recall_delta=args.recall_delta,
+            min_precision_ratio=args.min_precision_ratio,
+            ap_delta=args.ap_delta,
+        )
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    status = "PASS" if summary["claim_allowed"] else "FAIL"
+    print(f"Recall experiment: {status}")
+    print(f"Summary: {Path(args.output_dir) / 'recall_experiment_summary.json'}")
+    return 0 if summary["claim_allowed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_run_recall_experiment.py
+++ b/tests/test_run_recall_experiment.py
@@ -1,0 +1,127 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "run_recall_experiment.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("run_recall_experiment", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _sweep(recall, precision=0.80, checksum="manifest", ap=0.30):
+    return {
+        "mode": "sweep",
+        "average_precision": ap,
+        "validation_manifest": {"checksum": checksum},
+        "results": [
+            {
+                "confidence_threshold": 0.25,
+                "precision": precision,
+                "recall": recall,
+                "f1": 0.1,
+                "true_positives": 1,
+                "false_positives": 1,
+                "false_negatives": 1,
+            }
+        ],
+    }
+
+
+def test_precomputed_candidate_builds_experiment_outputs(tmp_path):
+    module = _load_module()
+    dataset_yaml = tmp_path / "combined_person.yaml"
+    dataset_yaml.write_text("train: images/train\nval: images/val\nnc: 1\nnames: ['person']\n", encoding="utf-8")
+    dataset_manifest = tmp_path / "combined_manifest.json"
+    dataset_manifest.write_text(json.dumps({"type": "sar-intel-combined-person-yolo-dataset", "summary": {"images": 2}}), encoding="utf-8")
+    baseline = tmp_path / "baseline.json"
+    candidate = tmp_path / "candidate.json"
+    baseline.write_text(json.dumps(_sweep(0.10, ap=0.20)), encoding="utf-8")
+    candidate.write_text(json.dumps(_sweep(0.20, precision=0.78, ap=0.28)), encoding="utf-8")
+
+    summary = module.run_precomputed_experiment(
+        dataset_yaml=dataset_yaml,
+        dataset_manifest=dataset_manifest,
+        baseline_sweep=baseline,
+        candidate_sweep=candidate,
+        output_dir=tmp_path / "experiment",
+        experiment_name="smoke",
+    )
+
+    out = tmp_path / "experiment"
+    assert (out / "training_metadata.json").exists()
+    assert (out / "candidate_sweep.json").exists()
+    assert (out / "finetune_report.json").exists()
+    assert (out / "recall_experiment_summary.json").exists()
+    assert summary["experiment_name"] == "smoke"
+    assert summary["claim_allowed"] is True
+    assert summary["dataset"]["manifest_sha256"]
+
+
+def test_precomputed_experiment_fails_for_missing_dataset_manifest(tmp_path):
+    module = _load_module()
+    dataset_yaml = tmp_path / "combined_person.yaml"
+    dataset_yaml.write_text("train: images/train\n", encoding="utf-8")
+    baseline = tmp_path / "baseline.json"
+    candidate = tmp_path / "candidate.json"
+    baseline.write_text(json.dumps(_sweep(0.10)), encoding="utf-8")
+    candidate.write_text(json.dumps(_sweep(0.20)), encoding="utf-8")
+
+    try:
+        module.run_precomputed_experiment(
+            dataset_yaml=dataset_yaml,
+            dataset_manifest=tmp_path / "missing.json",
+            baseline_sweep=baseline,
+            candidate_sweep=candidate,
+            output_dir=tmp_path / "experiment",
+        )
+    except FileNotFoundError as exc:
+        assert "dataset manifest" in str(exc)
+    else:
+        raise AssertionError("expected FileNotFoundError")
+
+
+def test_cli_precomputed_mode_writes_summary(tmp_path):
+    dataset_yaml = tmp_path / "combined_person.yaml"
+    dataset_yaml.write_text("train: images/train\n", encoding="utf-8")
+    dataset_manifest = tmp_path / "combined_manifest.json"
+    dataset_manifest.write_text(json.dumps({"summary": {"images": 2}}), encoding="utf-8")
+    baseline = tmp_path / "baseline.json"
+    candidate = tmp_path / "candidate.json"
+    baseline.write_text(json.dumps(_sweep(0.10, ap=0.20)), encoding="utf-8")
+    candidate.write_text(json.dumps(_sweep(0.20, precision=0.78, ap=0.28)), encoding="utf-8")
+    output_dir = tmp_path / "experiment"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/run_recall_experiment.py",
+            "--dataset-yaml",
+            str(dataset_yaml),
+            "--dataset-manifest",
+            str(dataset_manifest),
+            "--baseline-sweep",
+            str(baseline),
+            "--candidate-sweep",
+            str(candidate),
+            "--output-dir",
+            str(output_dir),
+            "--experiment-name",
+            "cli-smoke",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Recall experiment: PASS" in result.stdout
+    assert json.loads((output_dir / "recall_experiment_summary.json").read_text(encoding="utf-8"))["experiment_name"] == "cli-smoke"


### PR DESCRIPTION
## Summary
- add `scripts/run_recall_experiment.py`
- assemble dataset provenance, candidate sweep, fine-tune report, and summary into one experiment directory
- support CI-safe precomputed-candidate mode for now
- document the one-command recall experiment workflow

## Verification
- red test observed first: runner script missing
- `python -m pytest tests\test_run_recall_experiment.py tests\test_report_visdrone_finetune.py -q` -> 7 passed
- `python -m pytest` -> 93 passed
- `python scripts\verify_release.py`