### PR TITLE
[codex] Add training metadata capture

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,6 +23,7 @@ This roadmap is bold about direction and conservative about claims. Every new in
 - HERIDAL-style person-only YOLO conversion for the first external SAR-relevant training source
 - Combined person-YOLO dataset builder with source-prefixed files and provenance manifest
 - Recall experiment runner that links dataset provenance, candidate sweep, and fine-tune claim gate
+- Training metadata capture for dataset hashes, run parameters, and expected weights path
 
 ## Near-term
 

--- a/docs/TRAINING_VISDRONE.md
+++ b/docs/TRAINING_VISDRONE.md
@@ -63,8 +63,12 @@ python scripts/train_visdrone_person.py \
   --imgsz 640 \
   --batch auto \
   --project runs/visdrone_person \
-  --name yolo26n_visdrone_person
+  --name yolo26n_visdrone_person \
+  --dataset-manifest /path/to/datasets/visdrone_person/combined_manifest.json \
+  --metadata-output output/visdrone_training_metadata.json
 ```
+
+For a metadata-only dry run, add `--metadata-only`. This records dataset YAML hash, optional dataset manifest hash/payload, training parameters, expected best weights path, and timestamp without importing Ultralytics or using a GPU.
 
 ## Evaluate without threshold-shopping
 

--- a/scripts/train_visdrone_person.py
+++ b/scripts/train_visdrone_person.py
@@ -1,4 +1,7 @@
 import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -17,12 +20,83 @@ def parse_batch(value: str) -> int | float:
             raise argparse.ArgumentTypeError("batch must be an integer, float, or 'auto'.") from exc
 
 
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_training_metadata(
+    *,
+    dataset_yaml: str | Path,
+    dataset_manifest: str | Path | None,
+    model: str,
+    epochs: int,
+    imgsz: int,
+    batch: int | float,
+    project: str,
+    name: str,
+    best_path: str | Path,
+    save_dir: str | Path | None,
+    status: str,
+) -> dict[str, Any]:
+    dataset_yaml_path = Path(dataset_yaml)
+    dataset: dict[str, Any] = {
+        "yaml": str(dataset_yaml_path),
+        "yaml_sha256": sha256_file(dataset_yaml_path),
+    }
+    if dataset_manifest is not None:
+        manifest_path = Path(dataset_manifest)
+        if not manifest_path.exists():
+            raise FileNotFoundError(f"Missing dataset manifest: {manifest_path}")
+        dataset.update(
+            {
+                "manifest": str(manifest_path),
+                "manifest_sha256": sha256_file(manifest_path),
+                "manifest_payload": load_json(manifest_path),
+            }
+        )
+
+    return {
+        "type": "sar-intel-training-metadata",
+        "version": 1,
+        "status": status,
+        "created_at_utc": datetime.now(timezone.utc).isoformat(),
+        "dataset": dataset,
+        "training": {
+            "model": model,
+            "epochs": epochs,
+            "imgsz": imgsz,
+            "batch": batch,
+            "project": project,
+            "name": name,
+        },
+        "outputs": {
+            "save_dir": str(save_dir) if save_dir is not None else None,
+            "best_path": str(best_path),
+        },
+    }
+
+
+def write_training_metadata(metadata: dict[str, Any], path: str | Path) -> Path:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+    return output
+
+
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Train a person-only YOLO model on a prepared VisDrone dataset.")
+    parser = argparse.ArgumentParser(description="Train a person-only YOLO model on a prepared aerial-person dataset.")
     parser.add_argument(
         "--data",
         required=True,
-        help="Path to visdrone_person.yaml for the prepared YOLO dataset.",
+        help="Path to a prepared person-only YOLO dataset YAML.",
     )
     parser.add_argument(
         "--model",
@@ -34,6 +108,9 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--batch", type=parse_batch, default=-1, help="Training batch size, memory fraction, or 'auto'.")
     parser.add_argument("--project", default="runs/visdrone_person", help="Training project directory.")
     parser.add_argument("--name", default="yolo26n_visdrone_person", help="Training run name.")
+    parser.add_argument("--dataset-manifest", help="Optional combined dataset manifest JSON for provenance.")
+    parser.add_argument("--metadata-output", help="Where to write training metadata JSON.")
+    parser.add_argument("--metadata-only", action="store_true", help="Write metadata without importing Ultralytics or training.")
     return parser.parse_args(argv)
 
 
@@ -46,11 +123,39 @@ def run_training(
     batch: int | float,
     project: str,
     name: str,
+    dataset_manifest: str | Path | None = None,
+    metadata_output: str | Path | None = None,
+    metadata_only: bool = False,
 ) -> dict[str, Any]:
     dataset_yaml = Path(data)
     if not dataset_yaml.exists():
         raise FileNotFoundError(f"Missing training data file: {dataset_yaml}")
     expected_best_path = Path(project) / name / "weights" / "best.pt"
+
+    if metadata_only:
+        metadata = build_training_metadata(
+            dataset_yaml=dataset_yaml,
+            dataset_manifest=dataset_manifest,
+            model=model,
+            epochs=epochs,
+            imgsz=imgsz,
+            batch=batch,
+            project=project,
+            name=name,
+            best_path=expected_best_path,
+            save_dir=Path(project) / name,
+            status="metadata_only",
+        )
+        if metadata_output:
+            write_training_metadata(metadata, metadata_output)
+        return {
+            "dataset_yaml": str(dataset_yaml),
+            "save_dir": str(Path(project) / name),
+            "best_path": str(expected_best_path),
+            "model": model,
+            "metadata": metadata,
+            "metadata_output": str(metadata_output) if metadata_output else None,
+        }
 
     try:
         from ultralytics import YOLO
@@ -71,11 +176,28 @@ def run_training(
 
     results = trainer.train(**kwargs)
     save_dir = getattr(results, "save_dir", None)
+    metadata = build_training_metadata(
+        dataset_yaml=dataset_yaml,
+        dataset_manifest=dataset_manifest,
+        model=model,
+        epochs=epochs,
+        imgsz=imgsz,
+        batch=batch,
+        project=project,
+        name=name,
+        best_path=expected_best_path,
+        save_dir=save_dir,
+        status="trained",
+    )
+    if metadata_output:
+        write_training_metadata(metadata, metadata_output)
     return {
         "dataset_yaml": str(dataset_yaml),
         "save_dir": str(save_dir) if save_dir is not None else None,
         "best_path": str(expected_best_path),
         "model": model,
+        "metadata": metadata,
+        "metadata_output": str(metadata_output) if metadata_output else None,
     }
 
 
@@ -89,8 +211,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         batch=args.batch,
         project=args.project,
         name=args.name,
+        dataset_manifest=args.dataset_manifest,
+        metadata_output=args.metadata_output,
+        metadata_only=args.metadata_only,
     )
     print(f"likely_best_pt: {result['best_path']}")
+    if result.get("metadata_output"):
+        print(f"training_metadata: {result['metadata_output']}")
     return 0
 
 

--- a/tests/test_train_visdrone_person.py
+++ b/tests/test_train_visdrone_person.py
@@ -1,0 +1,88 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "train_visdrone_person.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("train_visdrone_person", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_training_metadata_includes_dataset_manifest_hash(tmp_path):
+    module = _load_module()
+    dataset_yaml = tmp_path / "combined_person.yaml"
+    dataset_yaml.write_text("train: images/train\n", encoding="utf-8")
+    dataset_manifest = tmp_path / "combined_manifest.json"
+    dataset_manifest.write_text(json.dumps({"summary": {"images": 12}}), encoding="utf-8")
+
+    metadata = module.build_training_metadata(
+        dataset_yaml=dataset_yaml,
+        dataset_manifest=dataset_manifest,
+        model="yolo26n.pt",
+        epochs=50,
+        imgsz=640,
+        batch=-1,
+        project="runs/visdrone_person",
+        name="exp1",
+        best_path=Path("runs/visdrone_person/exp1/weights/best.pt"),
+        save_dir=Path("runs/visdrone_person/exp1"),
+        status="planned",
+    )
+
+    assert metadata["type"] == "sar-intel-training-metadata"
+    assert metadata["dataset"]["yaml_sha256"]
+    assert metadata["dataset"]["manifest_sha256"]
+    assert metadata["dataset"]["manifest_payload"]["summary"]["images"] == 12
+    assert metadata["training"]["epochs"] == 50
+    assert metadata["outputs"]["best_path"].endswith("best.pt")
+
+
+def test_write_training_metadata_creates_parent_directory(tmp_path):
+    module = _load_module()
+    output = tmp_path / "nested" / "training_metadata.json"
+
+    module.write_training_metadata({"type": "sar-intel-training-metadata"}, output)
+
+    assert json.loads(output.read_text(encoding="utf-8"))["type"] == "sar-intel-training-metadata"
+
+
+def test_cli_metadata_only_writes_metadata_without_training(tmp_path):
+    dataset_yaml = tmp_path / "combined_person.yaml"
+    dataset_yaml.write_text("train: images/train\n", encoding="utf-8")
+    dataset_manifest = tmp_path / "combined_manifest.json"
+    dataset_manifest.write_text(json.dumps({"summary": {"images": 1}}), encoding="utf-8")
+    metadata_output = tmp_path / "training_metadata.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/train_visdrone_person.py",
+            "--data",
+            str(dataset_yaml),
+            "--dataset-manifest",
+            str(dataset_manifest),
+            "--metadata-output",
+            str(metadata_output),
+            "--metadata-only",
+            "--name",
+            "dry-run",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    metadata = json.loads(metadata_output.read_text(encoding="utf-8"))
+    assert metadata["status"] == "metadata_only"
+    assert metadata["training"]["name"] == "dry-run"
+    assert "training_metadata" in result.stdout


### PR DESCRIPTION
## Summary
- add training metadata capture to `scripts/train_visdrone_person.py`
- support `--dataset-manifest`, `--metadata-output`, and `--metadata-only`
- record dataset YAML hash, manifest hash/payload, run parameters, expected best weights path, and timestamp
- document metadata output in the training workflow

## Verification
- red test observed first: metadata functions/CLI flags missing
- `python -m pytest tests\test_train_visdrone_person.py tests\test_run_recall_experiment.py -q` -> 6 passed
- `python -m pytest` -> 96 passed
- `python scripts\verify_release.py`